### PR TITLE
Add gh-action for npm publish on release create

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,0 +1,19 @@
+name: Node.js Package
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    # Setup .npmrc file to publish to npm
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm install
+    - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 This module is maintained in the style of the MetaMask team.
 
-It uses:
+It features:
 - Typescript
 - Rollup
+- Jest
+- Eslint
+- Publishes to npm on each release (as long as `NPM_SECRET` is a [github secret](https://docs.github.com/en/actions/reference/encrypted-secrets)).
 
 ## Installation
 


### PR DESCRIPTION
Related to #31

Pulled directly off [the github actions example for this](https://docs.github.com/en/actions/guides/publishing-nodejs-packages).

[Additional notes on configuration on team Roam](https://roamresearch.com/#/app/MetaMask/page/t4mYLgOZK)