### PR TITLE
Use ES2020 lib in TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "inlineSources": true,
-    "lib": ["ES2017"],
+    "lib": ["ES2020"],
     "module": "ES6",
     "moduleResolution": "Node",
     "outDir": "dist",


### PR DESCRIPTION
Updates the `lib` field of `tsconfig.json` to use `ES2020` while still targeting `ES2017`.

We compile our TypeScript source using `tsc` to the `dist` folder, which produces `ES2017`-compatible code, even if we use `ES2020` features in our source code.