### PR TITLE
Implement standard dependabot

### DIFF
--- a/.github/dependabot.yml 
+++ b/.github/dependabot.yml 
@@ -10,3 +10,4 @@ updates:
       time: "06:00"
     target-branch: "main"
     versioning-strategy: "increase-if-necessary"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml 
+++ b/.github/dependabot.yml 
@@ -1,0 +1,14 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "main"
+    allow:
+      - dependency-name: "@metamask/*"
+        dependency-type: "development"
+    versioning-strategy: "increase-if-necessary"

--- a/.github/dependabot.yml 
+++ b/.github/dependabot.yml 
@@ -7,8 +7,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "06:00"
     target-branch: "main"
-    allow:
-      - dependency-name: "@metamask/*"
-        dependency-type: "development"
     versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
A few notes:

- `label`'s default value is `dependencies`, so I left that off
- `rebase-strategy`'s default value is `auto`, so I left that off
- `live` is not a supported YML setting, unfortunately, so to get "live" PRs opened when we update our own packages, we'll need to bump each dependabot file individually.

Also note that this config should be pretty portable -- one issue we'll need to rectify is the main branch name on different repositories differs.