### PR TITLE
Use only production updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       interval: "daily"
       time: "06:00"
+    allow:
+      - dependency-type: "production"
     target-branch: "main"
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 10


### PR DESCRIPTION
This will make dependabot less noisy.