### PR TITLE
Update prepublishOnly script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
-    "prepublishOnly": "yarn lint && yarn build",
+    "prepublishOnly": "yarn build && yarn lint && yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:json": "prettier '**/*.json' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:json --check",


### PR DESCRIPTION
Updates the `prepublishOnly` script to build, lint, and then test.

The reason we build first is because if we ever have e.g. JavaScript tests that are supposed to test things in `dist`, linting will fail if the build isn't up-to-date.