### PR TITLE
Update Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,12 @@ module.exports = {
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],
   preset: 'ts-jest',
+  // "resetMocks" resets all mocks, including mocked modules, to jest.fn(),
+  // between each test case.
   resetMocks: true,
+  // "restoreMocks" restores all mocks created using jest.spyOn to their
+  // original implementations, between each test. It does not affect mocked
+  // modules.
   restoreMocks: true,
   testEnvironment: 'node',
   testRegex: ['\\.test\\.(ts|js)$'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,9 @@ module.exports = {
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],
   preset: 'ts-jest',
+  resetMocks: true,
+  restoreMocks: true,
   testEnvironment: 'node',
-  testRegex: ['\\.test\\.ts$'],
-  testTimeout: 5000,
+  testRegex: ['\\.test\\.(ts|js)$'],
+  testTimeout: 2500,
 };


### PR DESCRIPTION
Updates the Jest config to:

- Include files ending in `.test.js`, not just `.test.ts`
- Reset mocks
- Restore mocks
- Decrease test timeout from 5000 to 2500 ms