### PR TITLE
Only use dependabot for metamask updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       interval: 'daily'
       time: '06:00'
     allow:
-      - dependency-type: 'production'
+      - dependency-name: '@metamask/*'
     target-branch: 'main'
     versioning-strategy: 'increase-if-necessary'
     open-pull-requests-limit: 10


### PR DESCRIPTION
As suggested by @rekmarks , let's only use dependabot for MetaMask updates.