### PR TITLE
Compile TypeScript modules to CommonJS instead of ES6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "esModuleInterop": true,
     "inlineSources": true,
     "lib": ["ES2020"],
-    "module": "ES6",
+    "module": "CommonJS",
     "moduleResolution": "Node",
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
This way, since `esModuleInterop` is `true`, our compiled `.js` files can be imported using both `require` and `import` without issue.