### PR TITLE
Remove unnecessary checkout

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,5 +28,4 @@ jobs:
     needs:
       - build-lint-test
     steps:
-      - uses: actions/checkout@v2
       - run: echo "Great success!"


### PR DESCRIPTION
The "all-jobs-pass" job no longer checks out the repository. [It had only included a checkout as a placeholder step](https://github.com/MetaMask/metamask-module-template/pull/19#discussion_r493757800), but this isn't necessary anymore now that we have the "Great success!" message. That can serve as our placeholder instead.