### PR TITLE
Clean the output directory on builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.yml' --single-quote --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
-    "build": "tsc --project ."
+    "build": "mkdir -p dist && rm -rf dist/* && tsc --project ."
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "setup": "yarn install && yarn allow-scripts",
     "test": "jest",
     "test:watch": "jest --watch",
-    "prepublishOnly": "yarn build && yarn lint && yarn test",
+    "prepublishOnly": "yarn build:clean && yarn lint && yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.yml' --single-quote --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
-    "build": "mkdir -p dist && rm -rf dist/* && tsc --project ."
+    "build:clean": "rimraf dist && yarn build",
+    "build": "tsc --project ."
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^1.0.5",
@@ -42,6 +43,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^26.4.2",
     "prettier": "^2.2.1",
+    "rimraf": "^3.0.2",
     "ts-jest": "^26.3.0",
     "typescript": "^4.2.4"
   },


### PR DESCRIPTION
`tsc` will overwrite any existing files, but it will not delete anything that's not a subset of its output. Therefore, we should manually clean the `dist` directory on builds. I'd bet money that we have published nonsense files because of this.