### PR TITLE
Collect coverage from all source files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   collectCoverage: true,
+  // Ensures that we collect coverage from all source files, not just tested
+  // ones.
+  collectCoverageFrom: ['./src/**.ts'],
   coverageReporters: ['text', 'html'],
   coverageThreshold: {
     global: {


### PR DESCRIPTION
Ensures that coverage is collected from all source files as opposed to just those that are tested. This behavior is controlled by the `collectCoverageFrom` field in `jest.config.js`.