### PR TITLE
Add .prettierrc.yml, don't run Prettier on CHANGELOG.md

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,5 +23,5 @@ module.exports = {
     },
   ],
 
-  ignorePatterns: ['!.eslintrc.js', 'dist/'],
+  ignorePatterns: ['!.eslintrc.js', '!.prettierrc.js', 'dist/'],
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,8 @@
+// All of these are defaults except singleQuote, but we specify them
+// for explicitness
+module.exports = {
+  quoteProps: 'as-needed',
+  singleQuote: true,
+  tabWidth: 2,
+  trailingComma: 'all',
+};

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,4 @@
+quoteProps: consistent
+singleQuote: true
+trailingComma: all
+tabWidth: 2

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,6 +1,0 @@
-# All of these are defaults except singleQuote, but we specify them
-# for explicitness
-quoteProps: as-needed
-singleQuote: true
-tabWidth: 2
-trailingComma: all

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,4 +1,6 @@
-quoteProps: consistent
+# All of these are defaults except singleQuote, but we specify them
+# for explicitness
+quoteProps: as-needed
 singleQuote: true
 tabWidth: 2
 trailingComma: all

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,4 +1,4 @@
 quoteProps: consistent
 singleQuote: true
-trailingComma: all
 tabWidth: 2
+trailingComma: all

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:watch": "jest --watch",
     "prepublishOnly": "yarn build:clean && yarn lint && yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.yml' --single-quote --ignore-path .gitignore",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.yml' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "build:clean": "rimraf dist && yarn build",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:watch": "jest --watch",
     "prepublishOnly": "yarn build:clean && yarn lint && yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.yml' --ignore-path .gitignore",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "build:clean": "rimraf dist && yarn build",


### PR DESCRIPTION
`@metamask/eslint-config` handles the Prettier configuration for `eslint-plugin-prettier`, but not for the use of `prettier` in e.g. the `lint:misc` package script.

This also updates the `lint:misc` script to exclude `CHANGELOG.md` from Prettier linting. This is because we're going to start auto-generating (and validating) changelogs using https://github.com/MetaMask/auto-changelog.