### PR TITLE
Use `actions/setup-node@v2` instead of `actions/setup-node@v1`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile


### PR DESCRIPTION
The latest version of `actions/setup-node@v2` appears to act the same, except that it has better caching.