### PR TITLE
Add 'Contributing' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,23 @@ _Add examples here_
 
 _Add examples here_
 
-## Testing
+## Contributing
 
-Run `yarn test` to run the tests once.
+### Setup
 
-To run tests on file changes, run `yarn test:watch`.
+- Install [Node.js](https://nodejs.org) version 12
+  - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
+- Install [Yarn v1](https://yarnpkg.com/en/docs/install)
+- Run `yarn setup` to install dependencies and run any requried post-install scripts
+  - **Warning**: Do not use the `yarn` / `yarn install` command directly. Use `yarn setup` instead. The normal install command will skip required post-install scripts, leaving your development environment in an invalid state.
 
-## Release & Publishing
+### Testing and Linting
+
+Run `yarn test` to run the tests once. To run tests on file changes, run `yarn test:watch`.
+
+Run `yarn lint` to run the linter, or run `yarn lint:fix` to run the linter and fix any automatically fixable issues.
+
+### Release & Publishing
 
 The project follows the same release process as the other libraries in the MetaMask organization:
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ _Add examples here_
   - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
 - Install [Yarn v1](https://yarnpkg.com/en/docs/install)
 - Run `yarn setup` to install dependencies and run any requried post-install scripts
-  - **Warning**: Do not use the `yarn` / `yarn install` command directly. Use `yarn setup` instead. The normal install command will skip required post-install scripts, leaving your development environment in an invalid state.
+  - **Warning:** Do not use the `yarn` / `yarn install` command directly. Use `yarn setup` instead. The normal install command will skip required post-install scripts, leaving your development environment in an invalid state.
 
 ### Testing and Linting
 


### PR DESCRIPTION
This section includes the test and release information that was present already, but adds a "Setup" section to explain how to setup the development environment. It also explains the `yarn setup` command, which is a common point of confusion for new contributors.

Linting instructions have been added alongside the test instructions as well.