### PR TITLE
Fix release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The project follows the same release process as the other libraries in the MetaM
    - To update an older maintained major version, base the release branch on the major version branch (e.g. `1.x`)
 2. Update the changelog
 3. Update version in package.json file (e.g. `yarn version --minor --no-git-tag-version`)
-4. Create a pull request targeting the base branch (e.g. master or 1.x)
+4. Create a pull request targeting the base branch (e.g. `main` or `1.x`)
 5. Code review and QA
 6. Once approved, the PR is squashed & merged
 7. The commit on the base branch is tagged


### PR DESCRIPTION
Step 4 of the release instructions still referenced the old main branch name (`master`). It has been updated to `main`. Also the branch names are now always in backticks.