### PR TITLE
Fix CI changelog validation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,10 +35,10 @@ jobs:
       - run: yarn lint
       - run: yarn test
       - name: Validate RC changelog
-        if: ${{ startsWith(github.ref, 'release/') }}
+        if: ${{ startsWith(github.head_ref, 'release/') }}
         run: yarn auto-changelog validate --rc
       - name: Validate changelog
-        if: ${{ !startsWith(github.ref, 'release/') }}
+        if: ${{ !startsWith(github.head_ref, 'release/') }}
         run: yarn auto-changelog validate
   all-jobs-pass:
     name: All jobs pass


### PR DESCRIPTION
When checking to see whether the current PR was for a release candidateor not, we were checking the wrong variable. `github.ref` contains the branch name if the action was triggered by a branch event, but in this case it's triggered by a `pull_request` event. For `pull_request` events, `github.ref` is set to `refs/pulls/[PR number]/merge`, so nothing was being recognized as a release candidate.

Instead it now checks `github.head_ref`, which is set to the branch name if it was triggered by `pull_request`. This workflow technically has two triggers: pushes to the `main` branch, and `pull_request`. But a push to the main branch is never a release candidate, so it's sufficient to just check `github.head_ref`.