### PR TITLE
Fix test coverage config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   collectCoverage: true,
   // Ensures that we collect coverage from all source files, not just tested
   // ones.
-  collectCoverageFrom: ['./src/**.ts'],
+  collectCoverageFrom: ['./src/**/*.ts'],
   coverageReporters: ['text', 'html'],
   coverageThreshold: {
     global: {


### PR DESCRIPTION
This PR fixes a typo in the `collectCoverageFrom` array in `jest.config.js` that excluded directories within `./src` from coverage collection.