### PR TITLE
Add git working tree check to CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,6 +32,13 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn allow-scripts
       - run: yarn build
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty after building"
+            exit 1
+          fi
       - run: yarn lint
       - run: yarn test
       - name: Validate RC changelog

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,13 +32,6 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn allow-scripts
       - run: yarn build
-      - name: Require clean working directory
-        shell: bash
-        run: |
-          if ! git diff --exit-code; then
-            echo "Working tree dirty after building"
-            exit 1
-          fi
       - run: yarn lint
       - run: yarn test
       - name: Validate RC changelog
@@ -47,6 +40,13 @@ jobs:
       - name: Validate changelog
         if: ${{ !startsWith(github.head_ref, 'release/') }}
         run: yarn auto-changelog validate
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty after building"
+            exit 1
+          fi
   all-jobs-pass:
     name: All jobs pass
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Adds a `! git diff --exit-code` check to CI after the build step to ensure that the working tree remains clean after building. We don't expect to _need_ this check for every repository, but it should always pass for every repository, and is very fast as well!