### PR TITLE
Prevent prettier error on unmatched patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "jest --watch",
     "prepublishOnly": "yarn build:clean && yarn lint && yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --ignore-path .gitignore",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "build:clean": "rimraf dist && yarn build",


### PR DESCRIPTION
Add the `--no-error-on-unmatched-pattern` flag to the `prettier` invocation to prevent it from erroring if a particular file pattern is not matched. The patterns we have may be unmatched in certain repositories, for example in monorepos without `.yml` files in a particular package.

The reason we want to ignore these errors rather than remove the unmatched patterns is because it's very easy to forget to add them back should matching files be added, and then those files will not be linted for a potentially long period of time.