### PR TITLE
Typecheck Jest config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,14 +21,6 @@ module.exports = {
       files: ['*.test.ts', '*.test.js'],
       extends: ['@metamask/eslint-config-jest'],
     },
-
-    {
-      files: ['jest.config.ts'],
-      rules: {
-        // TODO: Migrate to our shared config
-        'import/no-anonymous-default-export': 'off',
-      },
-    },
   ],
 
   ignorePatterns: ['!.eslintrc.js', '!.prettierrc.js', 'dist/'],

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,9 @@
  * https://jestjs.io/docs/configuration
  */
 
-export default {
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
   // All imported modules in your tests should be mocked automatically
   // automock: false,
 
@@ -202,3 +204,5 @@ export default {
   // Whether to use watchman for file crawling
   // watchman: true,
 };
+
+export default config;


### PR DESCRIPTION
The Jest documentation includes a [TypeScript example][1] that
suggests how a user-provided config object can be typechecked. This
commit incorporates these suggestions. Because we assign the default
export to a variable first, this obviates the need to turn off the
ESLint `import/no-anonymous-default-export` rule.

[1]: https://jestjs.io/docs/configuration