### PR TITLE
Bump prettier-plugin-packagejson to ^2.2.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,16 +12,16 @@
     "dist/"
   ],
   "scripts": {
+    "build": "tsc --project .",
+    "build:clean": "rimraf dist && yarn build",
+    "lint": "yarn lint:eslint && yarn lint:misc --check",
+    "lint:eslint": "eslint . --cache --ext js,ts",
+    "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern",
+    "prepublishOnly": "yarn build:clean && yarn lint && yarn test",
     "setup": "yarn install && yarn allow-scripts",
     "test": "jest",
-    "test:watch": "jest --watch",
-    "prepublishOnly": "yarn build:clean && yarn lint && yarn test",
-    "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern",
-    "lint": "yarn lint:eslint && yarn lint:misc --check",
-    "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
-    "build:clean": "rimraf dist && yarn build",
-    "build": "tsc --project ."
+    "test:watch": "jest --watch"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^1.0.5",
@@ -43,7 +43,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^27.5.1",
     "prettier": "^2.2.1",
-    "prettier-plugin-packagejson": "^2.2.11",
+    "prettier-plugin-packagejson": "^2.2.17",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3794,12 +3794,12 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier-plugin-packagejson@^2.2.11:
-  version "2.2.11"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.2.11.tgz#640b6301da3a58c489889b3d315255e18153daf0"
-  integrity sha512-oJCBCEkHIKScEv6qNQC47S39NXlevbzwvoJE3gflmBB8/3BEsC6ZRi+hwFVajw32b4tDI9hFXPIzmVd/T8Rm9w==
+prettier-plugin-packagejson@^2.2.17:
+  version "2.2.17"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.2.17.tgz#fc5c93203f9091ad063d9ea5960d2e1a989b94ac"
+  integrity sha512-Z1l3stIdkEzuv5w2ZyLl7mvl1Q/7vr2wjLAaKCQtafPHB7h09dir0tgXK/W5iEc/jP+C4XtvJl/HhiZBvPh4rQ==
   dependencies:
-    sort-package-json "1.50.0"
+    sort-package-json "1.55.0"
 
 prettier@^2.2.1:
   version "2.2.1"
@@ -4093,10 +4093,10 @@ sort-object-keys@^1.1.3:
   resolved "https://registry.yarnpkg.com/sort-object-keys/-/sort-object-keys-1.1.3.tgz#bff833fe85cab147b34742e45863453c1e190b45"
   integrity sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==
 
-sort-package-json@1.50.0:
-  version "1.50.0"
-  resolved "https://registry.yarnpkg.com/sort-package-json/-/sort-package-json-1.50.0.tgz#19fc109fe23bd157bd03c8e572fa3251a52467d8"
-  integrity sha512-qZpqhMU9XTntebgAgc4hv/D6Fzhh7kFnwvV6a7+q8y8J5JoaDqPYQnvXPf7BBqG95tdE8X6JVNo7/jDzcbdfUg==
+sort-package-json@1.55.0:
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/sort-package-json/-/sort-package-json-1.55.0.tgz#150328328a9ac8b417b43d5a1fae74e5f27254e9"
+  integrity sha512-xhKvRD8WGbALjXQkVuk4/93Z/2NIO+5IzKamdMjN5kn3L+N+M9YWQssmM6GXlQr9v1F7PGWsOJEo1gvXOhM7Mg==
   dependencies:
     detect-indent "^6.0.0"
     detect-newline "3.1.0"


### PR DESCRIPTION
Although 2.2.17 is a patch bump from 2.2.11,
`prettier-plugin-packagejson` now depends on `sort-package-json` 1.55.0
rather than 1.50.0, which changes how the `scripts` section in
`package.json` is ordered: namely, that it is now alphabetized. This can
be seen in projects that make use of the module template where 2.2.17 of
`prettier-plugin-packagejson `is installed (as it is the latest
version). This commit updates the version to match so that if
`package.json` is updated it is sorted in the same manner.