### PR TITLE
Extract build-only TypeScript config

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "tsc --project .",
+    "build": "tsc --project tsconfig.build.json",
     "build:clean": "rimraf dist && yarn build",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,9 +2,11 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "inlineSources": true,
     "noEmit": false,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "sourceMap": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["./src/**/*.test.ts"]

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "noEmit": false,
+    "outDir": "dist",
     "rootDir": "src"
   },
   "include": ["./src/**/*.ts"],

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./src/**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "esModuleInterop": true,
     "inlineSources": true,
     "lib": ["ES2020"],
     "module": "CommonJS",
     "moduleResolution": "node",
-    "outDir": "dist",
+    "noEmit": true,
     "sourceMap": true,
     "strict": true,
     "target": "es2017"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "strict": true,
     "target": "es2017"
   },
-  "exclude": ["./dist/**"]
+  "exclude": ["./dist/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,13 +5,10 @@
     "inlineSources": true,
     "lib": ["ES2020"],
     "module": "CommonJS",
-    "moduleResolution": "Node",
+    "moduleResolution": "node",
     "outDir": "dist",
-    "rootDir": "src",
     "sourceMap": true,
     "strict": true,
-    "target": "ES2017"
-  },
-  "exclude": ["./src/**/*.test.ts"],
-  "include": ["./src/**/*.ts"]
+    "target": "es2017"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,6 @@
     "noEmit": true,
     "strict": true,
     "target": "es2017"
-  }
+  },
+  "exclude": ["./dist/**"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,10 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "inlineSources": true,
     "lib": ["ES2020"],
     "module": "CommonJS",
     "moduleResolution": "node",
     "noEmit": true,
-    "sourceMap": true,
     "strict": true,
     "target": "es2017"
   }


### PR DESCRIPTION
Currently, test files are excluded from TypeScript's purview via the
`exclude` option in `tsconfig.json`. This is helpful when compiling
because it means that test files will not be included in the build
directory. However, for development, this is unnecessary, as we want
TypeScript to "see" and resolve types across all files in the project.

This commit splits off the build-specific settings from `tsconfig.json`
into a `tsconfig.build.json` file, which will exclusively be used in the
`yarn build` script.