### PR TITLE
Enable forceConsistentCasingInFileNames: true

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
     "lib": ["ES2020"],
     "module": "CommonJS",
     "moduleResolution": "node",


### PR DESCRIPTION
The filesystem used by macOS features case-insensitive lookup behavior:
if a file `foo.ts` exists, it can be referred to using `Foo.ts`. The
filesystems that Windows and Linux (at least historically) use, however,
exhibit case-sensitive lookup behavior. Usually TypeScript uses the same
rules as the filesystem on which it's running, so if `Foo.ts` is a valid
way to refer to a file `foo.ts`, then technically, it can be imported
the same way. With `forceConsistentCasingInFileNames` it will no longer
honor the native filesystem behavior and will enforce that a file is
imported using the exact name as it has been given.

See: <https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames>

---

Fixes #103.