### PR TITLE
Add jest-it-up

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,25 +34,17 @@ jobs:
       - run: yarn build
       - run: yarn lint
       - run: yarn test
-      # Intended to catch any coverage-related changes
-      - name: Require clean working directory after testing
-        shell: bash
-        run: |
-          if ! git diff --exit-code; then
-            echo "Working tree dirty after testing"
-            exit 1
-          fi
       - name: Validate RC changelog
         if: ${{ startsWith(github.head_ref, 'release/') }}
         run: yarn auto-changelog validate --rc
       - name: Validate changelog
         if: ${{ !startsWith(github.head_ref, 'release/') }}
         run: yarn auto-changelog validate
-      - name: Require clean working directory after building
+      - name: Require clean working directory
         shell: bash
         run: |
           if ! git diff --exit-code; then
-            echo "Working tree dirty after building"
+            echo "Working tree dirty at the end of CI job"
             exit 1
           fi
   all-jobs-pass:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,13 +34,21 @@ jobs:
       - run: yarn build
       - run: yarn lint
       - run: yarn test
+      # Intended to catch any coverage-related changes
+      - name: Require clean working directory after testing
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty after testing"
+            exit 1
+          fi
       - name: Validate RC changelog
         if: ${{ startsWith(github.head_ref, 'release/') }}
         run: yarn auto-changelog validate --rc
       - name: Validate changelog
         if: ${{ !startsWith(github.head_ref, 'release/') }}
         run: yarn auto-changelog validate
-      - name: Require clean working directory
+      - name: Require clean working directory after building
         shell: bash
         run: |
           if ! git diff --exit-code; then

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           if ! git diff --exit-code; then
-            echo "Working tree dirty at the end of CI job"
+            echo "Working tree dirty at end of job"
             exit 1
           fi
   all-jobs-pass:

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,7 @@
  * https://jestjs.io/docs/configuration
  */
 
-import type { Config } from '@jest/types';
-
-const config: Config.InitialOptions = {
+module.exports = {
   // All imported modules in your tests should be mocked automatically
   // automock: false,
 
@@ -38,7 +36,7 @@ const config: Config.InitialOptions = {
   coverageProvider: 'v8',
 
   // A list of reporter names that Jest uses when writing coverage reports
-  coverageReporters: ['text', 'html'],
+  coverageReporters: ['html', 'json-summary', 'text'],
 
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
@@ -204,5 +202,3 @@ const config: Config.InitialOptions = {
   // Whether to use watchman for file crawling
   // watchman: true,
 };
-
-export default config;

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern",
     "prepublishOnly": "yarn build:clean && yarn lint && yarn test",
     "setup": "yarn install && yarn allow-scripts",
-    "test": "jest",
-    "posttest": "jest-it-up",
+    "test": "jest && jest-it-up",
     "test:watch": "jest --watch"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "prepublishOnly": "yarn build:clean && yarn lint && yarn test",
     "setup": "yarn install && yarn allow-scripts",
     "test": "jest",
-    "test:watch": "jest --watch",
-    "posttest": "jest-it-up"
+    "posttest": "jest-it-up",
+    "test:watch": "jest --watch"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "prepublishOnly": "yarn build:clean && yarn lint && yarn test",
     "setup": "yarn install && yarn allow-scripts",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "posttest": "jest-it-up"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^1.0.5",
@@ -42,6 +43,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^27.5.1",
+    "jest-it-up": "^2.0.2",
     "prettier": "^2.2.1",
     "prettier-plugin-packagejson": "^2.2.17",
     "rimraf": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,6 +520,38 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@inquirer/confirm@^0.0.14-alpha.0":
+  version "0.0.14-alpha.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-0.0.14-alpha.0.tgz#4a759c6def5ecd73bc239e090ee6197f74f52dbd"
+  integrity sha512-MTMCp/jUHJUB0IVkV5utQ1NUE3tqH2W0OtYXByW+ykoRXLiaYrv8vYtx6j0/rOiDHhNjNqTEIWomQx16w1x0uQ==
+  dependencies:
+    "@inquirer/core" "^0.0.15-alpha.0"
+    "@inquirer/input" "^0.0.15-alpha.0"
+    chalk "^4.1.1"
+
+"@inquirer/core@^0.0.15-alpha.0":
+  version "0.0.15-alpha.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-0.0.15-alpha.0.tgz#08b6439f3998669d1ba0165c0c5f91736b0c7848"
+  integrity sha512-aytWU6/yM9HkZ09BrgfTJlVsZjmxoiO1cBL5tlkO/jYe4ZuU84rHWnFFxorRzkmT6gkTs1L9TUKaeK3tbyJmJw==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-spinners "^2.6.0"
+    cli-width "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "^0.0.8"
+    run-async "^2.3.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+"@inquirer/input@^0.0.15-alpha.0":
+  version "0.0.15-alpha.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-0.0.15-alpha.0.tgz#60556547845775ac332d7b3406717f361b3ef721"
+  integrity sha512-h3mxEK9xTtdAX6a+S/pYRVRTxpnjOPQgQADpgFar/yQqklyBRM5+uX1YRRQG+uwU0IzpI18viPnEdibxrY7Kyw==
+  dependencies:
+    "@inquirer/core" "^0.0.15-alpha.0"
+    chalk "^4.1.1"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1182,6 +1214,11 @@ ajv@^7.0.2:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+ansi-colors@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
+
 ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
@@ -1497,6 +1534,14 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -1516,6 +1561,16 @@ cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
+
+cli-spinners@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.1.tgz#adc954ebe281c37a6319bfa401e6dd2488ffb70d"
+  integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -1571,6 +1626,11 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^9.0.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.3.0.tgz#f619114a5a2d2054e0d9ff1b31d5ccf89255e26b"
+  integrity sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==
 
 comment-parser@1.2.4:
   version "1.2.4"
@@ -2919,6 +2979,15 @@ jest-haste-map@^27.5.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
+jest-it-up@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/jest-it-up/-/jest-it-up-2.0.2.tgz#c8c38d14fd4a9131c12f6947baa2063554c0738d"
+  integrity sha512-xup3Lv1uc+ihGwyFLjZOqY2L7m91TyBp/TRJxS7PYAVQc/vd3NbkPyypUlT59sQDfW9uULF9jLCedr7jABDNnA==
+  dependencies:
+    "@inquirer/confirm" "^0.0.14-alpha.0"
+    ansi-colors "^4.1.0"
+    commander "^9.0.0"
+
 jest-jasmine2@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.5.1.tgz#a037b0034ef49a9f3d71c4375a796f3b230d1ac4"
@@ -3461,6 +3530,11 @@ ms@2.1.2, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+mute-stream@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -4000,6 +4074,11 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+run-async@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
 run-parallel@^1.1.9:
   version "1.2.0"


### PR DESCRIPTION
Adds `jest-it-up` to the template. [`jest-it-up`](https://github.com/rbardini/jest-it-up) is a neat package that detects when coverage has increased, and automatically your coverage minimums in the Jest config. The only requirements made of your Jest config are that (1) it is a conventional `jest.config.js` file and (2) its `coverageReporters` includes `json-summary`. Consequently, this PR converts the Jest config file from TypeScript back to plain JavaScript, and adds the required coverage reporter.

I believe that the benefits conferred by `jest-it-up` outweigh those of using TypeScript for the config file, which rarely changes and is never consumed by application code. Meanwhile,  `json-summary` outputs a single JSON file to the `coverage/` directory and does not appear to impact performance.