### PR TITLE
Don't truncate info/error messages from TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "noEmit": true,
+    "noErrorTruncation": true,
     "strict": true,
     "target": "es2017"
   },


### PR DESCRIPTION
I have found, when debugging TypeScript errors, that said errors can get
truncated if the types involved are even remotely non-trivial. I have
also found that type information which appears on hover can get
truncated sometimes as well. This can be frustrating, but fortunately,
the `noErrorTruncation` option in `tsconfig.json` can be used to turn
this off. I don't think that many people know about this option, and I'm
not sure why it's `false` by default, but here we flip it to `true`.