### PR TITLE
Add `SKIP_PREPACK` environment variable to publish actions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -62,6 +62,8 @@ jobs:
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
         uses: MetaMask/action-npm-publish@v1.1.0
+        env:
+          SKIP_PREPACK: true
 
   publish-npm:
     environment: npm-publish
@@ -84,3 +86,5 @@ jobs:
           # This `NPM_TOKEN` needs to be manually set per-repository.
           # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.
           npm-token: ${{ secrets.NPM_TOKEN }}
+        env:
+          SKIP_PREPACK: true

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' '!.yarnrc.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern",
-    "prepack": "yarn build",
+    "prepack": "./scripts/prepack.sh",
     "test": "jest && jest-it-up",
     "test:watch": "jest --watch"
   },

--- a/scripts/prepack.sh
+++ b/scripts/prepack.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -o pipefail
+
+if [[ -n $SKIP_PREPACK ]]; then
+  echo "Notice: skipping prepack."
+  exit 0
+fi
+
+yarn build


### PR DESCRIPTION
This adds the missing `SKIP_PREPACK` environment variable to the publish actions, to avoid running scripts.