### PR TITLE
Remove invalid `runs-on` from publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -100,7 +100,6 @@ jobs:
         run: ./scripts/get.sh ".version" "RELEASE_VERSION"
 
   publish-release-to-gh-pages:
-    runs-on: ubuntu-latest
     needs: get-release-version
     name: Publish docs to `${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
     permissions:
@@ -110,7 +109,6 @@ jobs:
       destination_dir: ${{ needs.get-release-version.outputs.RELEASE_VERSION }}
 
   publish-release-to-latest-gh-pages:
-    runs-on: ubuntu-latest
     needs: publish-npm
     name: Publish docs to `latest` directory of `gh-pages` branch
     permissions:


### PR DESCRIPTION
`runs-on` is not compatible with `uses`/`with`:

```
The workflow is not valid. .github/workflows/publish-release.yml
(Line: 108, Col: 5): Unexpected value 'uses' .github/workflows/publish-release.yml
(Line: 109, Col: 5): Unexpected value 'with'
```

https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow

I added this on accident in #123.