### PR TITLE
Check out repository in `get-release-version` for publishing docs

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -95,6 +95,9 @@ jobs:
     outputs:
       RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.sha }}
       - id: get-release-version
         shell: bash
         run: ./scripts/get.sh ".version" "RELEASE_VERSION"


### PR DESCRIPTION
`get-release-version` was missing a checkout, so running it would result in an error because the script cannot be found.