### PR TITLE
Replace deprecated GitHub actions commands

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -31,7 +31,7 @@ jobs:
           ref: ${{ github.event.inputs.base-branch }}
       - name: Get Node.js version
         id: nvm
-        run: echo "::set-output name=NODE_VERSION::$(cat .nvmrc)"
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,16 +21,16 @@ jobs:
         uses: actions/checkout@v3
       - name: Get Node.js version
         id: nvm
-        run: echo "::set-output name=NODE_VERSION::$(cat .nvmrc)"
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
       - name: Setup Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - name: Get Yarn cache directory
-        run: echo "::set-output name=YARN_CACHE_DIR::$(yarn config get cacheFolder)"
+        run: echo "YARN_CACHE_DIR=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
         id: yarn-cache-dir
       - name: Get Yarn version
-        run: echo "::set-output name=YARN_VERSION::$(yarn --version)"
+        run: echo "YARN_VERSION=$(yarn --version)" >> "$GITHUB_OUTPUT"
         id: yarn-version
       - name: Cache yarn dependencies
         uses: actions/cache@v3

--- a/.github/workflows/publish-rc-docs.yml
+++ b/.github/workflows/publish-rc-docs.yml
@@ -15,7 +15,7 @@ jobs:
         id: release-name
         run: |
           BRANCH_NAME='${{ github.ref_name }}'
-          echo "::set-output name=RELEASE_VERSION::v${BRANCH_NAME#release/}"
+          echo "RELEASE_VERSION=v${BRANCH_NAME#release/}" >> "$GITHUB_OUTPUT"
   publish-to-gh-pages:
     name: Publish docs to `rc-${{ needs.get-release-version.outputs.release-version }}` directory of `gh-pages` branch
     permissions:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,7 +27,7 @@ jobs:
           ref: ${{ github.sha }}
       - name: Get Node.js version
         id: nvm
-        run: echo "::set-output name=NODE_VERSION::$(cat .nvmrc)"
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -18,4 +18,4 @@ if [[ -z $OUTPUT ]]; then
   exit 1
 fi
 
-echo "::set-output name=$OUTPUT::$(jq --raw-output "$KEY" package.json)"
+echo "$OUTPUT=$(jq --raw-output "$KEY" package.json)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
`::set-output` is deprecated. This replaces it with the updated way to do it.