### PR TITLE
ci: change image tag from ubuntu-20.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   prepare:
     name: Prepare
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       YARN_CACHE_DIR: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
       YARN_VERSION: ${{ steps.yarn-version.outputs.YARN_VERSION }}
@@ -36,7 +36,7 @@ jobs:
         run: yarn --immutable
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - prepare
     strategy:
@@ -64,7 +64,7 @@ jobs:
           fi
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - prepare
     strategy:
@@ -98,7 +98,7 @@ jobs:
           fi
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - prepare
     strategy:
@@ -126,7 +126,7 @@ jobs:
           fi
   check-workflows:
     name: Check workflows
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Download actionlint
@@ -138,7 +138,7 @@ jobs:
         shell: bash
   all-jobs-pass:
     name: All jobs pass
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - build
       - lint

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish-docs-to-gh-pages:
     name: Publish docs to GitHub Pages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/publish-rc-docs.yml
+++ b/.github/workflows/publish-rc-docs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   get-release-version:
     name: Get release version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       release-version: ${{ steps.release-name.outputs.RELEASE_VERSION }}
     steps:


### PR DESCRIPTION
Turns out `ubuntu-latest` is [still](https://github.com/actions/runner-images#available-images) pointing at `ubuntu-20.04`, so this currently does not do anything. It's intended to normalize tagging with other workflows, and make sure runners stay up to date without need for manual updates. This is in line with GH general recommendations.

https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/

