### PR TITLE
Bump `actionlint` to 1.6.22

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Download actionlint
         id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/d5f726fb9c9aaff30c8c3787a9b9640f7612838a/scripts/download-actionlint.bash) 1.6.21
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.22
         shell: bash
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color


### PR DESCRIPTION
`actionlint@1.6.22` has some nice improvements like removing and detecting use of the deprecated workflow commands.