### PR TITLE
Run publish after build, lint, test completed successfully

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,6 +34,7 @@ jobs:
           key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}-${{ matrix.node-version }}
       - name: Install Yarn dependencies
         run: yarn --immutable
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -62,6 +63,7 @@ jobs:
             echo "Working tree dirty at end of job"
             exit 1
           fi
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -96,6 +98,7 @@ jobs:
             echo "Working tree dirty at end of job"
             exit 1
           fi
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -124,6 +127,7 @@ jobs:
             echo "Working tree dirty at end of job"
             exit 1
           fi
+
   check-workflows:
     name: Check workflows
     runs-on: ubuntu-latest
@@ -136,6 +140,7 @@ jobs:
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color
         shell: bash
+
   all-jobs-pass:
     name: All jobs pass
     runs-on: ubuntu-latest
@@ -146,3 +151,23 @@ jobs:
       - check-workflows
     steps:
       - run: echo "Great success!"
+
+  is-release:
+    # release merge commits come from github-actions
+    if: startsWith(github.event.commits[0].author.name, 'github-actions')
+    needs:
+      - all-jobs-pass
+    outputs:
+      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MetaMask/action-is-release@v1
+        id: is-release
+
+  publish-release:
+    needs: is-release
+    if: needs.is-release.outputs.IS_RELEASE == 'true'
+    name: Publish release
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-release.yml

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,26 +1,13 @@
 name: Publish Release
 
 on:
-  push:
-    branches: [main]
+  workflow_call:
 
 jobs:
-  is-release:
-    # release merge commits come from github-actions
-    if: startsWith(github.event.commits[0].author.name, 'github-actions')
-    outputs:
-      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: MetaMask/action-is-release@v1
-        id: is-release
-
   publish-release:
     permissions:
       contents: write
-    if: needs.is-release.outputs.IS_RELEASE == 'true'
     runs-on: ubuntu-latest
-    needs: is-release
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This makes the publish workflow only run after the build, lint, and test steps have completed successfully. It does a workflow call to `publish-release.yml`, if the current commit is a release commit.