### PR TITLE
Update action-npm-publish to support Yarn protocols

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,7 +26,9 @@ jobs:
       - uses: actions/cache@v3
         id: restore-build
         with:
-          path: ./dist
+          path: |
+            ./dist
+            ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
 
   publish-npm-dry-run:
@@ -39,13 +41,13 @@ jobs:
       - uses: actions/cache@v3
         id: restore-build
         with:
-          path: ./dist
+          path: |
+            ./dist
+            ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
-        # Set `ignore-scripts` to skip `prepublishOnly` because the release was built already in the previous job
-      - run: npm config set ignore-scripts true
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
-        uses: MetaMask/action-npm-publish@v1
+        uses: MetaMask/action-npm-publish@v2
         env:
           SKIP_PREPACK: true
 
@@ -60,12 +62,12 @@ jobs:
       - uses: actions/cache@v3
         id: restore-build
         with:
-          path: ./dist
+          path: |
+            ./dist
+            ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
-        # Set `ignore-scripts` to skip `prepublishOnly` because the release was built already in the previous job
-      - run: npm config set ignore-scripts true
       - name: Publish
-        uses: MetaMask/action-npm-publish@v1
+        uses: MetaMask/action-npm-publish@v2
         with:
           # This `NPM_TOKEN` needs to be manually set per-repository.
           # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.


### PR DESCRIPTION
The action `MetaMask/action-npm-publish` has been updated to v2, which uses Yarn for publishing rather than npm. This ensures the publish step works correctly with Yarn-specific dependency protocols such as `workspace:`.

The `.yarn-state.yml` file needs to be cached and restored during publish to ensure that Yarn can run the `prepack` script. The prepack step is a no-op here because we have `SKIP_PREPACK` set, but there is no way to tell Yarn to not attempt running it.

Since we're no longer using npm, we don't need to set `ignore-scripts` in the npm config anymore either.