### PR TITLE
Use `actions/setup-node` cache

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,9 +9,6 @@ jobs:
   prepare:
     name: Prepare
     runs-on: ubuntu-latest
-    outputs:
-      YARN_CACHE_DIR: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
-      YARN_VERSION: ${{ steps.yarn-version.outputs.YARN_VERSION }}
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x, 19.x]
@@ -21,17 +18,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Get Yarn cache directory
-        run: echo "YARN_CACHE_DIR=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
-        id: yarn-cache-dir
-      - name: Get Yarn version
-        run: echo "YARN_VERSION=$(yarn --version)" >> "$GITHUB_OUTPUT"
-        id: yarn-version
-      - name: Cache Yarn dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
-          key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}-${{ matrix.node-version }}
+          cache: 'yarn2'
       - name: Install Yarn dependencies
         run: yarn --immutable
 
@@ -49,11 +36,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Restore Yarn dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ needs.prepare.outputs.YARN_CACHE_DIR }}
-          key: yarn-cache-${{ runner.os }}-${{ needs.prepare.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}-${{ matrix.node-version }}
+          cache: 'yarn2'
       - run: yarn --immutable
       - run: yarn build
       - name: Require clean working directory
@@ -78,11 +61,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Restore Yarn dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ needs.prepare.outputs.YARN_CACHE_DIR }}
-          key: yarn-cache-${{ runner.os }}-${{ needs.prepare.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}-${{ matrix.node-version }}
+          cache: 'yarn2'
       - run: yarn --immutable
       - run: yarn lint
       - name: Validate RC changelog
@@ -113,11 +92,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Restore Yarn dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ needs.prepare.outputs.YARN_CACHE_DIR }}
-          key: yarn-cache-${{ runner.os }}-${{ needs.prepare.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}-${{ matrix.node-version }}
+          cache: 'yarn2'
       - run: yarn --immutable
       - run: yarn test
       - name: Require clean working directory


### PR DESCRIPTION
[`actions/setup-node` has an option to cache dependencies](https://github.com/actions/setup-node#caching-global-packages-data), which essentially does what we were doing manually, using. `actions/cache` internally. Using it means we can remove the manual caching step.