### PR TITLE
Reorganize GitHub Action workflows

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -1,9 +1,7 @@
 name: Build, Lint, and Test
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+  workflow_call:
 
 jobs:
   prepare:
@@ -99,49 +97,3 @@ jobs:
             echo "Working tree dirty at end of job"
             exit 1
           fi
-
-  check-workflows:
-    name: Check workflows
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Download actionlint
-        id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.22
-        shell: bash
-      - name: Check workflow files
-        run: ${{ steps.download-actionlint.outputs.executable }} -color
-        shell: bash
-
-  all-jobs-pass:
-    name: All jobs pass
-    runs-on: ubuntu-latest
-    needs:
-      - build
-      - lint
-      - test
-      - check-workflows
-    steps:
-      - run: echo "Great success!"
-
-  is-release:
-    # release merge commits come from github-actions
-    if: startsWith(github.event.commits[0].author.name, 'github-actions')
-    needs:
-      - all-jobs-pass
-    outputs:
-      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: MetaMask/action-is-release@v1
-        id: is-release
-
-  publish-release:
-    needs: is-release
-    if: needs.is-release.outputs.IS_RELEASE == 'true'
-    name: Publish release
-    permissions:
-      contents: write
-    uses: ./.github/workflows/publish-release.yml
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,5 +52,3 @@ jobs:
     uses: ./.github/workflows/publish-release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check-workflows
-      - lint-build-test
+      - build-lint-test
     steps:
       - run: echo "Great success!"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,56 @@
+name: Main
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check-workflows:
+    name: Check workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download actionlint
+        id: download-actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.22
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.download-actionlint.outputs.executable }} -color
+        shell: bash
+
+  build-lint-test:
+    name: Build, lint, and test
+    uses: ./.github/workflows/build-lint-test.yml
+
+  all-jobs-pass:
+    name: All jobs pass
+    runs-on: ubuntu-latest
+    needs:
+      - check-workflows
+      - lint-build-test
+    steps:
+      - run: echo "Great success!"
+
+  is-release:
+    # release merge commits come from github-actions
+    if: startsWith(github.event.commits[0].author.name, 'github-actions')
+    needs: all-jobs-pass
+    outputs:
+      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MetaMask/action-is-release@v1
+        id: is-release
+
+  publish-release:
+    needs: is-release
+    if: needs.is-release.outputs.IS_RELEASE == 'true'
+    name: Publish release
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-release.yml
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+


### PR DESCRIPTION
The workflows have been reorganized to use one "main" workflow for any push to the main branch, with additional jobs being triggered from there using `workflow_call`. This mirrors the change made recently in the controllers repository as part of the monorepo branch.

This makes more sense semantically every since we moved the publish step to be triggered by a push to `main`. Since then, it seend wrong to call that workflow "build-test" because it also did publishing. Now the "build-test" workflow is distinct, and it's the "main" workflow that triggers publishing.