### PR TITLE
Improve compatibility of `is-release` job condition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,8 +50,13 @@ jobs:
           fi
 
   is-release:
-    # release merge commits come from github-actions
-    if: startsWith(github.event.commits[0].author.name, 'github-actions')
+    # `push` events only trigger this workflow on the `main` branch, so that event indiciates this
+    # is a commit to `main`.
+    # `MetaMask/action-is-release` does not work correctly for `pull_request` events either
+    # See https://github.com/MetaMask/action-is-release/issues/3
+    # This action should work reliably as long as it's only ron on `push` events on the main
+    # branch, in a repository that only allows "Squash & merge" commits on the main branch.
+    if: github.event_name == 'push'
     needs: all-jobs-pass
     outputs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,12 +50,11 @@ jobs:
           fi
 
   is-release:
-    # `push` events only trigger this workflow on the `main` branch, so that event indiciates this
-    # is a commit to `main`.
-    # `MetaMask/action-is-release` does not work correctly for `pull_request` events either
-    # See https://github.com/MetaMask/action-is-release/issues/3
-    # This action should work reliably as long as it's only run on `push` events on the main
-    # branch, in a repository that only allows "Squash & merge" commits on the main branch.
+    # Filtering by `push` events ensures that we only release from the `main` branch, which is a
+    # requirement for our npm publishing environment.
+    # The commit author should always be 'github-actions' for releases created by the
+    # 'create-release-branch' workflow, so we filter by that as well to prevent accidentally
+    # triggering a release.
     if: github.event_name == 'push' && startsWith(github.event.head_commit.author.name, 'github-actions')
     needs: all-jobs-pass
     outputs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
     # See https://github.com/MetaMask/action-is-release/issues/3
     # This action should work reliably as long as it's only run on `push` events on the main
     # branch, in a repository that only allows "Squash & merge" commits on the main branch.
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && startsWith(github.event.head_commit.author.name, 'github-actions')
     needs: all-jobs-pass
     outputs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
     # Filtering by `push` events ensures that we only release from the `main` branch, which is a
     # requirement for our npm publishing environment.
     # The commit author should always be 'github-actions' for releases created by the
-    # 'create-release-branch' workflow, so we filter by that as well to prevent accidentally
+    # 'create-release-pr' workflow, so we filter by that as well to prevent accidentally
     # triggering a release.
     if: github.event_name == 'push' && startsWith(github.event.head_commit.author.name, 'github-actions')
     needs: all-jobs-pass

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     # is a commit to `main`.
     # `MetaMask/action-is-release` does not work correctly for `pull_request` events either
     # See https://github.com/MetaMask/action-is-release/issues/3
-    # This action should work reliably as long as it's only ron on `push` events on the main
+    # This action should work reliably as long as it's only run on `push` events on the main
     # branch, in a repository that only allows "Squash & merge" commits on the main branch.
     if: github.event_name == 'push'
     needs: all-jobs-pass


### PR DESCRIPTION
The `is-release` job condition now includes a check for the event trigger type, preventing it from running on `pull_request` events. This ensures we only release from the main branch, and it acts as further protection against running the `action-is-release` action in response to a `pull_request` event (it fails with a confusing error in that situation).

The comment has been improved as well.

Original description:

The `is-release` job condition is now compatible with more release workflows. Previously it assumed that release commits were made by GitHub Actions, but that's not true anymore in some of our repositories.

Instead, we now ensure just that the triggering event was a `push` event. `push` events are only triggered on this workflow for the main branch, so that will omit any events from PRs. It also ensures that the `action-is-release` action is not triggered for `pull_request` events, which it does not currently support.

`action-is-release` should correctly identify releases, so long as it's only run on the `main` branch for `push` events in a repository that only allows `Squash & merge` commits on the main branch. These requirements have been explained in a comment.