### PR TITLE
Ignore `.yarn` folder in ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,5 +23,11 @@ module.exports = {
     },
   ],
 
-  ignorePatterns: ['!.eslintrc.js', '!.prettierrc.js', 'dist/', 'docs/'],
+  ignorePatterns: [
+    '!.eslintrc.js',
+    '!.prettierrc.js',
+    'dist/',
+    'docs/',
+    '.yarn/',
+  ],
 };


### PR DESCRIPTION
The `.yarn` folder contains auto-generated files, and should not be linted by ESLint.

I've added the folder to the `ignorePatterns` to prevent this.