### PR TITLE
Prefer Babel for Jest coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -33,7 +33,7 @@ module.exports = {
   // ],
 
   // Indicates which provider should be used to instrument code for coverage
-  coverageProvider: 'v8',
+  coverageProvider: 'babel',
 
   // A list of reporter names that Jest uses when writing coverage reports
   coverageReporters: ['html', 'json-summary', 'text'],


### PR DESCRIPTION
`babel` is the default value for `coverageProvider` and since we've seen some weird behaviour with `v8` I propose we use the default instead.