### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:
+
+* What is the current state of things and why does it need to change?
+* What is the solution your changes offer and how does it work?
+
+Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:
+
+* Fixes #12345
+* See: #67890
+-->
+
+## Examples
+
+<!--
+Are there any examples of this change being used in another repository?
+
+When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Thanks for your contribution! Take a moment to answer these questions so that re
 * What is the current state of things and why does it need to change?
 * What is the solution your changes offer and how does it work?
 
-Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:
+Are there any issues or other links reviewers should consult to understand this pull request better? For instance:
 
 * Fixes #12345
 * See: #67890

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Follow these instructions when using this template.
 - Update the package description
   - The package description is referenced at the beginning of the README, and in the `description` field of `package.json`.
 - Update the `repository` field of `package.json` to point at the new repository URL.
+- Update the pull request template (`.github/pull_request_template.md`) to remove the `Examples` section that is specific to this template.
 - Update the README "Usage" and "API" sections, removing them if they aren't needed.
 - Delete these instructions.
 


### PR DESCRIPTION
A PR template has been added to describe what we want from PRs. It asks for a clear description of changes, references to related issues/PRs, and examples of the change being suggested.