### PR TITLE
Fix mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ _Add examples here_
 
 ### Setup
 
-- Install [Node.js](https://nodejs.org) version 16
+- Install [Node.js](https://nodejs.org) version 14
   - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
 - Install [Yarn v3](https://yarnpkg.com/getting-started/install)
 - Run `yarn install` to install dependencies and run any required post-install scripts


### PR DESCRIPTION
The README mistakenly referenced Node.js v16 as a setup step. This template still uses Node.js v14.