### PR TITLE
Use PAT for publishing docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,3 +73,4 @@ jobs:
     uses: ./.github/workflows/publish-release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,6 +6,9 @@ on:
       destination_dir:
         required: true
         type: string
+    secrets:
+      PUBLISH_DOCS_TOKEN:
+        required: true
 
 jobs:
   publish-docs-to-gh-pages:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,6 +11,7 @@ jobs:
   publish-docs-to-gh-pages:
     name: Publish docs to GitHub Pages
     runs-on: ubuntu-latest
+    environment: github-pages
     permissions:
       contents: write
     steps:
@@ -31,6 +32,8 @@ jobs:
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
         uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # This `PUBLISH_DOCS_TOKEN` needs to be manually set per-repository.
+          # Look in the repository settings under "Environments", and set this token in the `github-pages` environment.
+          personal_token: ${{ secrets.PUBLISH_DOCS_TOKEN }}
           publish_dir: ./docs
           destination_dir: ${{ inputs.destination_dir }}

--- a/.github/workflows/publish-main-docs.yml
+++ b/.github/workflows/publish-main-docs.yml
@@ -12,3 +12,5 @@ jobs:
     uses: ./.github/workflows/publish-docs.yml
     with:
       destination_dir: staging
+    secrets:
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}

--- a/.github/workflows/publish-rc-docs.yml
+++ b/.github/workflows/publish-rc-docs.yml
@@ -24,3 +24,5 @@ jobs:
     needs: get-release-version
     with:
       destination_dir: rc-${{ needs.get-release-version.outputs.release-version }}
+    secrets:
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,8 @@ on:
     secrets:
       NPM_TOKEN:
         required: true
+      PUBLISH_DOCS_TOKEN:
+        required: true
 
 jobs:
   publish-release:
@@ -99,6 +101,8 @@ jobs:
     uses: ./.github/workflows/publish-docs.yml
     with:
       destination_dir: ${{ needs.get-release-version.outputs.RELEASE_VERSION }}
+    secrets:
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
 
   publish-release-to-latest-gh-pages:
     needs: publish-npm
@@ -108,3 +112,5 @@ jobs:
     uses: ./.github/workflows/publish-docs.yml
     with:
       destination_dir: latest
+    secrets:
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}


### PR DESCRIPTION
The `publish-docs` workflow has been updated to use a personal access token for publishing docs instead of using the `GITHUB_TOKEN`. This allows for more control over doc publishing permissions.

Fixes #184

## Examples

This has been implemented in the `utils` library: https://github.com/MetaMask/utils/pull/96