### PR TITLE
Update ESLint test config to include Node.js rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,10 @@ module.exports = {
 
     {
       files: ['*.test.ts', '*.test.js'],
-      extends: ['@metamask/eslint-config-jest'],
+      extends: [
+        '@metamask/eslint-config-jest',
+        '@metamask/eslint-config-nodejs',
+      ],
     },
   ],
 


### PR DESCRIPTION
The ESLint configuration for test modules now includes Node.js lint rules. Our jest tests are always run with Node.js.

This was done recently in https://github.com/MetaMask/eth-json-rpc-provider/pull/6 to allow the use of Node.js globals in tests.