### PR TITLE
Update GitHub Actions docs action to remove dependency on Node.js 12

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run build script
         run: yarn build:docs
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
-        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
+        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs


### PR DESCRIPTION
I've updated `peaceiris/actions-gh-pages` to a more recent version which does not use Node.js 12 anymore for running the action. Node.js 12 has been end-of-life for some time now.