### PR TITLE
Target `ES2020`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "noErrorTruncation": true,
     "noUncheckedIndexedAccess": true,
     "strict": true,
-    "target": "es2017"
+    "target": "es2020"
   },
   "exclude": ["./dist/**/*"]
 }


### PR DESCRIPTION
After https://github.com/MetaMask/metamask-extension/commit/524ab66a16ace5d2088800c9c1203f42e5e1acbd has been merged, I believe we can start letting our modules target `ES2020`.

https://caniuse.com/?feats=mdn-javascript_operators_optional_chaining,mdn-javascript_operators_nullish_coalescing,mdn-javascript_builtins_globalthis,es6-module-dynamic-import,bigint,mdn-javascript_builtins_promise_allsettled,mdn-javascript_builtins_string_matchall,mdn-javascript_statements_export_namespace,mdn-javascript_operators_import_meta

Open to thoughts and feedback from the team!
