### PR TITLE
Generate source maps for `.d.ts` files

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "inlineSources": true,
     "noEmit": false,
     "outDir": "dist",


### PR DESCRIPTION


<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

It is a frustrating experience to want to see the source code of a module that's being imported in one's editor only to be presented with the `.d.ts` file when the module is Cmd-clicked (or "Go to Definition" is invoked). To fix this, TypeScript needs to be configured to generate source maps alongside `.d.ts` files.

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->

I can enable this in the `core` repo first to see how this would work in practice.