### PR TITLE
Changed node version in packagejson to match nvmrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "packageManager": "yarn@3.2.1",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
The nvmrc file specifies v16, the package.json#engines says greater than 14. This PR makes them both 16.

as an aside, using un-specific versions in nvmrc is discouraged. We should be specifying the exact version of node to be used.