### PR TITLE
Update release-type description

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -8,7 +8,7 @@ on:
         default: 'main'
         required: true
       release-type:
-        description: 'A SemVer version diff, i.e. major, minor, patch, prerelease etc. Mutually exclusive with "release-version".'
+        description: 'A SemVer version diff, i.e. major, minor, or patch. Mutually exclusive with "release-version".'
         required: false
       release-version:
         description: 'A specific version to bump to. Mutually exclusive with "release-type".'


### PR DESCRIPTION
## Description

`release-type` can only be `major`, `minor`, or `patch`. The description has been updated to accurately reflect this.

## Changes

1. Update the description of `release-type` field in the `create-release-pr` workflow.