### PR TITLE
Remove the `-x` flag from Bash scripts

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -x
 set -e
 set -u
 set -o pipefail

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -4,6 +4,10 @@ set -e
 set -u
 set -o pipefail
 
+if [[ ${RUNNER_DEBUG:-0} == 1 ]]; then
+  set -x
+fi
+
 KEY="${1}"
 OUTPUT="${2}"
 

--- a/scripts/prepack.sh
+++ b/scripts/prepack.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -x
 set -e
 set -o pipefail
 


### PR DESCRIPTION
The `-x` flag is typically used for debugging. When used in production, it can clutter the console output and make it difficult to tell what's happening.

The flag has been removed from the two small Bash scripts in this template.

## Examples

This was done recently in this PR: https://github.com/MetaMask/eth-trezor-keyring/pull/182
