### PR TITLE
Replace devs team with engineering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/devs
+*                                    @MetaMask/engineering

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Follow these instructions when using this template.
   - The links in the API section of the README
 - Update the pull request template (`.github/pull_request_template.md`) to remove the `Examples` section that is specific to this template.
 - Update the README "Usage" section, or remove it if it's not needed.
+- Update the CODEOWNERs file to set the appropriate code owners for the repository (typically one or more engineering teams)
+  - Ensure each referenced team has write permission, and that the engineering team still has write permission.
 - Delete these instructions.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Follow these instructions when using this template.
   - The links in the API section of the README
 - Update the pull request template (`.github/pull_request_template.md`) to remove the `Examples` section that is specific to this template.
 - Update the README "Usage" section, or remove it if it's not needed.
-- Update the CODEOWNERs file to set the appropriate code owners for the repository (typically one or more engineering teams)
+- Update the CODEOWNERS file to set the appropriate code owners for the repository (typically one or more engineering teams)
   - Ensure each referenced team has write permission, and that the engineering team still has write permission.
 - Delete these instructions.
 


### PR DESCRIPTION
The CODEOWNERS file has been updated to use the new engineering team instead of the old devs team.

The README has been updated with instructions on updating the CODEOWNERS file as well, since we no longer want to use a single team as the code owners in most cases.

## Examples

We intentionally aren't using the engineering team anywhere as a codeowner, but it's the best default we have.