### PR TITLE
ci: Run compatibility test ignoring lockfile

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -124,7 +124,7 @@ jobs:
           fi
 
   compatibility-test:
-    name: Compatibility Test
+    name: Compatibility test
     runs-on: ubuntu-latest
     needs:
       - prepare


### PR DESCRIPTION
This adds an additional run of tests against a state where `yarn.lock` is removed prior to the installation. This is intended to catch e.g. regressions and mislabeled breakage in updated transitive dependencies.

This will map more closely to what users get when installing the released package from registry.

Left out the intermediate versions of node as an optimization. The normal cache is still used since significant overlap is expected.

### Potential future improvements

- Run test against built package under another package manager (yarn v1 and/or npm)
  - Ensure there aren't implicit dependencies on yarn berry
  - Would allow throwing on breakages in `engines` without adding a plugin

