### PR TITLE
Run build and lint steps in CI on `.nvmrc` Node version

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -22,15 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - prepare
-    strategy:
-      matrix:
-        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - run: yarn --immutable --immutable-cache
       - run: yarn build:source
@@ -47,15 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - prepare
-    strategy:
-      matrix:
-        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - run: yarn --immutable --immutable-cache
       - run: yarn build:types
@@ -72,15 +66,12 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - prepare
-    strategy:
-      matrix:
-        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - run: yarn --immutable --immutable-cache
       - run: yarn lint


### PR DESCRIPTION
This changes the build and lint steps in CI to only run on the `.nvmrc` version. The Node version for these steps shouldn't matter. The test step is still run on all supported Node versions.

We made this change in a few other repositories already, but it was never applied to the module template.