### PR TITLE
Exclude node_modules from TS compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "strict": true,
     "target": "es2020"
   },
-  "exclude": ["./dist", "./node_modules"]
+  "exclude": ["./dist", "**/node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "strict": true,
     "target": "es2020"
   },
-  "exclude": ["./dist/**/*"]
+  "exclude": ["./dist", "./node_modules"]
 }


### PR DESCRIPTION
TypeScript excludes `node_modules` by default (among other directories) if you don't specify `exclude` in the TS config, but if you specify `exclude`, then you need to make to explicitly list `node_modules`.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->

I believe we have started adding this slowly as we've remembered, but here is the latest example: https://github.com/MetaMask/create-release-branch/pull/93