### PR TITLE
Fix 'yarn pack'

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup && yarn build:types",
-    "build:clean": "rimraf dist && yarn build",
+    "build": "tsup --clean && yarn build:types",
     "build:docs": "typedoc",
     "build:types": "tsc --project tsconfig.build.json",
     "lint": "yarn lint:eslint && yarn lint:constraints && yarn lint:misc --check && yarn lint:dependencies --check && yarn lint:changelog",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   ],
   "scripts": {
     "build": "tsup && yarn build:types",
+    "build:clean": "rimraf dist && yarn build",
     "build:docs": "typedoc",
     "build:types": "tsc --project tsconfig.build.json",
     "lint": "yarn lint:eslint && yarn lint:constraints && yarn lint:misc --check && yarn lint:dependencies --check && yarn lint:changelog",

--- a/scripts/prepack.sh
+++ b/scripts/prepack.sh
@@ -8,4 +8,4 @@ if [[ -n $SKIP_PREPACK ]]; then
   exit 0
 fi
 
-yarn build:clean
+yarn build


### PR DESCRIPTION
The `yarn pack` command is run by the `npm-publish` action prior to publishing the package. Unfortunately, this command does not work as the `prepack` lifecycle script is overridden to run `yarn build:clean`, which was removed when this repo was converted to use `tsup` for building. `tsup` already clears the `dist` directly, so in practice a `build:clean` script is not usually necessary, but there are occasions where we want to _really_ be sure that `dist` does not exist, and publishing is one of them. Hence, this commit adds back `build:clean`, which should fix `yarn pack` and the publishing workflow.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Testing

Running `yarn pack` should not produce any errors.

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->

N/A, as this is a bugfix to this repo.