### PR TITLE
ci: run `corepack enable` before installing dependencies

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -8,14 +8,18 @@ jobs:
     name: Prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
+          node-version: 'lts/*'
       - name: Install Yarn
         run: corepack enable
+      - uses: actions/checkout@v4
+      - name: Use Node.js and install dependencies
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'yarn'
       - name: Install Yarn dependencies
         run: yarn --immutable
 
@@ -25,11 +29,17 @@ jobs:
     needs:
       - prepare
     steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+      - name: Install Yarn
+        run: corepack enable
       - uses: actions/checkout@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version: 'lts/*'
           cache: 'yarn'
       - run: yarn --immutable --immutable-cache
       - run: yarn build
@@ -47,11 +57,17 @@ jobs:
     needs:
       - prepare
     steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+      - name: Install Yarn
+        run: corepack enable
       - uses: actions/checkout@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version: 'lts/*'
           cache: 'yarn'
       - run: yarn --immutable --immutable-cache
       - run: yarn lint
@@ -78,6 +94,12 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
     steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Yarn
+        run: corepack enable
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -103,6 +125,12 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
     steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Yarn
+        run: corepack enable
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
+      - name: Install Yarn
+        run: corepack enable
       - name: Install Yarn dependencies
         run: yarn --immutable
 


### PR DESCRIPTION
`corepack` is not currently supported in `@actions/setup-node` and this means installation of dependencies fail when using yarn >v1:
- https://github.com/actions/setup-node/pull/901

This hacks around it by running `@actions/setup-node` twice: once before checkout to install the node-version, so that `corepack enable` can be run, after which the normal flow starting with checkout can proceed.

Since `.nvmrc` is not available before checkout, it also implies not using `.nvmrc` to specify node-version for this workflow anymore.

An alternative to this would be forking `@actions/setup-node` with the patch from the PR linked above but sounds not worth it.