### PR TITLE
chore: unpin yarn@^4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "typedoc": "^0.23.15",
     "typescript": "~4.8.4"
   },
-  "packageManager": "yarn@4.1.1",
+  "packageManager": "yarn@^4.1.1",
   "engines": {
     "node": "^18.18 || >=20"
   },


### PR DESCRIPTION
Should be reasonable to allow later yarn 4.x versions.

Related:
- #243 
- #244