### PR TITLE
Fix other workflows to install Corepack as prereq

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -7,41 +7,47 @@ jobs:
   prepare:
     name: Prepare
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
     steps:
-      - name: Use Node.js
+      - uses: actions/checkout@v4
+      - name: Install Corepack via Node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version-file: '.nvmrc'
       - name: Install Yarn
         run: corepack enable
-      - uses: actions/checkout@v4
-      - name: Use Node.js and install dependencies
+      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - name: Install Yarn dependencies
+      - name: Install dependencies via Yarn
         run: yarn --immutable
 
   build:
     name: Build
+    needs: prepare
     runs-on: ubuntu-latest
-    needs:
-      - prepare
+    strategy:
+      matrix:
+        node-version: [20.x]
     steps:
-      - name: Use Node.js
+      - uses: actions/checkout@v4
+      - name: Install Corepack via Node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version-file: '.nvmrc'
       - name: Install Yarn
         run: corepack enable
-      - uses: actions/checkout@v4
-      - name: Use Node.js
+      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - name: Install dependencies via Yarn
+        run: yarn --immutable --immutable-cache
       - run: yarn build
       - name: Require clean working directory
         shell: bash
@@ -53,23 +59,26 @@ jobs:
 
   lint:
     name: Lint
+    needs: prepare
     runs-on: ubuntu-latest
-    needs:
-      - prepare
+    strategy:
+      matrix:
+        node-version: [20.x]
     steps:
-      - name: Use Node.js
+      - uses: actions/checkout@v4
+      - name: Install Corepack via Node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version-file: '.nvmrc'
       - name: Install Yarn
         run: corepack enable
-      - uses: actions/checkout@v4
-      - name: Use Node.js
+      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - name: Install dependencies via Yarn
+        run: yarn --immutable --immutable-cache
       - run: yarn lint
       - name: Validate RC changelog
         if: ${{ startsWith(github.head_ref, 'release/') }}
@@ -87,26 +96,26 @@ jobs:
 
   test:
     name: Test
+    needs: prepare
     runs-on: ubuntu-latest
-    needs:
-      - prepare
     strategy:
       matrix:
         node-version: [18.x, 20.x]
     steps:
-      - name: Use Node.js
+      - uses: actions/checkout@v4
+      - name: Install Corepack via Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
       - name: Install Yarn
         run: corepack enable
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - name: Install dependencies via Yarn
+        run: yarn --immutable --immutable-cache
       - run: yarn test
       - name: Require clean working directory
         shell: bash
@@ -118,31 +127,32 @@ jobs:
 
   compatibility-test:
     name: Compatibility test
+    needs: prepare
     runs-on: ubuntu-latest
-    needs:
-      - prepare
     strategy:
       matrix:
         node-version: [18.x, 20.x]
     steps:
-      - name: Use Node.js
+      - uses: actions/checkout@v4
+      - name: Install Corepack via Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
       - name: Install Yarn
         run: corepack enable
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: rm yarn.lock && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
+      - name: Install dependencies via Yarn
+        run: rm yarn.lock && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
       - run: yarn test
+      - name: Restore lockfile
+        run: git restore yarn.lock
       - name: Require clean working directory
         shell: bash
         run: |
-          git restore yarn.lock
           if ! git diff --exit-code; then
             echo "Working tree dirty at end of job"
             exit 1

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -29,13 +29,13 @@ jobs:
           # We check out the specified branch, which will be used as the base
           # branch for all git operations and the release PR.
           ref: ${{ github.event.inputs.base-branch }}
-      - name: Setup Node.js
+      - name: Install Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - uses: MetaMask/action-create-release-pr@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           release-type: ${{ github.event.inputs.release-type }}
           release-version: ${{ github.event.inputs.release-version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,14 +21,19 @@ jobs:
       - name: Ensure `destination_dir` is not empty
         if: ${{ inputs.destination_dir == '' }}
         run: exit 1
-      - name: Checkout the repository
-        uses: actions/checkout@v4
-      - name: Use Node.js
+      - uses: actions/checkout@v4
+      - name: Install Corepack via Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install Yarn
+        run: corepack enable
+      - name: Restore Yarn cache
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
-      - name: Install npm dependencies
+      - name: Install dependencies via Yarn
         run: yarn --immutable
       - name: Run build script
         run: yarn build:docs

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,34 +19,48 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
-      - name: Setup Node.js
+      - name: Install Corepack via Node
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+      - name: Install Yarn
+        run: corepack enable
+      - name: Restore Yarn cache
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
       - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install
-        run: |
-          yarn install
-          yarn build
       - uses: actions/cache@v3
-        id: restore-build
         with:
           path: |
             ./dist
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
+      - run: yarn --immutable
+      - run: yarn build
 
   publish-npm-dry-run:
-    runs-on: ubuntu-latest
     needs: publish-release
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
+      - name: Install Corepack via Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install Yarn
+        run: corepack enable
+      - name: Restore Yarn cache
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
       - uses: actions/cache@v3
-        id: restore-build
         with:
           path: |
             ./dist
@@ -62,15 +76,25 @@ jobs:
           SKIP_PREPACK: true
 
   publish-npm:
-    environment: npm-publish
-    runs-on: ubuntu-latest
     needs: publish-npm-dry-run
+    runs-on: ubuntu-latest
+    environment: npm-publish
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
+      - name: Install Corepack via Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install Yarn
+        run: corepack enable
+      - name: Restore Yarn cache
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
       - uses: actions/cache@v3
-        id: restore-build
         with:
           path: |
             ./dist
@@ -86,8 +110,8 @@ jobs:
           SKIP_PREPACK: true
 
   get-release-version:
-    runs-on: ubuntu-latest
     needs: publish-npm
+    runs-on: ubuntu-latest
     outputs:
       RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
     steps:
@@ -99,8 +123,8 @@ jobs:
         run: ./scripts/get.sh ".version" "RELEASE_VERSION"
 
   publish-release-to-gh-pages:
-    needs: get-release-version
     name: Publish docs to `${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
+    needs: get-release-version
     permissions:
       contents: write
     uses: ./.github/workflows/publish-docs.yml
@@ -110,8 +134,8 @@ jobs:
       PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
 
   publish-release-to-latest-gh-pages:
-    needs: publish-npm
     name: Publish docs to `latest` directory of `gh-pages` branch
+    needs: publish-npm
     permissions:
       contents: write
     uses: ./.github/workflows/publish-docs.yml


### PR DESCRIPTION
A recent commit upgraded the version of Yarn to v4 and removed the Yarn binary from the repo, thereby requiring that Corepack be installed in order to install dependencies. The `build-lint-test` was updated to install Corepack, but not the documentation-related workflows, so they are failing.

This commit fixes those workflows to install Corepack. It also cleans up some work that was done in previous commits:

- In the `build-lint-test` workflow we ensure that `prepare` is run once per Node version we are testing and that `build` and `lint` use the latest Node version we are testing.
- In steps where we are installing Node just to gain access to the `corepack` executable, we use `.nvmrc` (the version of Node we use for development) to know which version of Node to install rather than using the latest LTS (`lts/*`). For jobs that do not need to concern themselves with being run in multiple Node versions, this ensures that consistent Node versions are used in this step vs. the step that is used to simply restore the Yarn cache.
- The checkout step always goes first, this way `.nvmrc` can be read.