### PR TITLE
chore: Use Node 22

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Install Corepack via Node
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Install Corepack via Node
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Install Corepack via Node
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Install Corepack via Node
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Install Corepack via Node

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "packageManager": "yarn@4.1.1",
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": "^18.20 || ^20.17 || >=22"
   },
   "publishConfig": {
     "access": "public",

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -179,7 +179,7 @@ async function expectPullRequestTemplate(workspace, workspaceName) {
 
   const pullRequestTemplate = await getWorkspaceFile(
     workspace,
-    '.github/PULL_REQUEST_TEMPLATE.md',
+    '.github/pull_request_template.md',
   );
 
   if (!pullRequestTemplate) {
@@ -253,8 +253,8 @@ module.exports = defineConfig({
     workspace.set('repository.type', 'git');
     workspace.set('repository.url', `${workspaceRepository}.git`);
 
-    // The package must specify a minimum Node.js version of 18.18.
-    workspace.set('engines.node', '^18.18 || >=20');
+    // The package must specify the expected minimum Node versions
+    workspace.set('engines.node', '^18.20 || ^20.17 || >=22');
 
     // The package must provide the location of the CommonJS-compatible
     // entrypoint and its matching type declaration file.


### PR DESCRIPTION
[As of October 29](https://github.com/nodejs/Release/tree/87462aac66fe3ce1ee1e3f812af83ccef9873782), Node.js 22 is the active `lts` version, and we should start to configure our repositories to use it as the latest supported version. This also updates our minimum supported Node versions for 18 and 20.