### PR TITLE
Bump `@ts-bridge/cli` to `^0.6.3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@metamask/eslint-config-jest": "^14.0.0",
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^28.1.6",
     "@types/node": "^18.18",
     "@yarnpkg/types": "^4.0.0-rc.52",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,7 +1075,7 @@ __metadata:
     "@metamask/eslint-config-jest": "npm:^14.0.0"
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^28.1.6"
     "@types/node": "npm:^18.18"
     "@yarnpkg/types": "npm:^4.0.0-rc.52"
@@ -1342,9 +1342,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ts-bridge/cli@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@ts-bridge/cli@npm:0.6.0"
+"@ts-bridge/cli@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "@ts-bridge/cli@npm:0.6.3"
   dependencies:
     "@ts-bridge/resolver": "npm:^0.2.0"
     chalk: "npm:^5.3.0"
@@ -1355,7 +1355,7 @@ __metadata:
   bin:
     ts-bridge: ./dist/index.js
     tsbridge: ./dist/index.js
-  checksum: 10/a23da563b99c56124538fbaf77a2d7a0ad01c898c86ab3be527e3dbe0b22f380daa9207bfeffd8591508ed878959ba168daf6197e06822ba8a3b62dfd7396dab
+  checksum: 10/01cba56ff0f097ca0ef15b79cff80a6be07b7f237e7153f63f7a9acf911583d0a410385fa1711d7b14e3a5e95fed63310b6a743700e7ecc0dd3a2d97a0df75b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This bumps `@ts-bridge/cli` to `^0.6.3`, which solves a couple issues related to type imports and exports.