### PR TITLE
Implement `MetaMask/action-checkout-and-setup`

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -11,7 +11,8 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: MetaMask/action-checkout-and-setup@v1
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
@@ -25,7 +26,8 @@ jobs:
       matrix:
         node-version: [22.x]
     steps:
-      - uses: MetaMask/action-checkout-and-setup@v1
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
@@ -46,7 +48,8 @@ jobs:
       matrix:
         node-version: [22.x]
     steps:
-      - uses: MetaMask/action-checkout-and-setup@v1
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
@@ -73,7 +76,8 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: MetaMask/action-checkout-and-setup@v1
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
@@ -94,7 +98,8 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: MetaMask/action-checkout-and-setup@v1
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
+          node-version: ${{ matrix.node-version }}
           cache-node-modules: ${{ matrix.node-version == '22.x' }}
 
   build:
@@ -27,6 +28,7 @@ jobs:
       - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
+          node-version: ${{ matrix.node-version }}
       - run: yarn build
       - name: Require clean working directory
         shell: bash
@@ -47,6 +49,7 @@ jobs:
       - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
+          node-version: ${{ matrix.node-version }}
       - run: yarn lint
       - name: Validate RC changelog
         if: ${{ startsWith(github.head_ref, 'release/') }}
@@ -73,6 +76,7 @@ jobs:
       - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
+          node-version: ${{ matrix.node-version }}
       - run: yarn test
       - name: Require clean working directory
         shell: bash
@@ -93,6 +97,7 @@ jobs:
       - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
+          node-version: ${{ matrix.node-version }}
       - name: Install dependencies via Yarn
         run: rm yarn.lock && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
       - run: yarn test

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -11,20 +11,10 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - uses: MetaMask/action-checkout-and-setup@main
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - name: Install dependencies via Yarn
-        run: yarn --immutable
+          is-high-risk-environment: false
+          cache-node-modules: true
 
   build:
     name: Build
@@ -34,20 +24,9 @@ jobs:
       matrix:
         node-version: [22.x]
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - uses: MetaMask/action-checkout-and-setup@main
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - name: Install dependencies via Yarn
-        run: yarn --immutable --immutable-cache
+          is-high-risk-environment: false
       - run: yarn build
       - name: Require clean working directory
         shell: bash
@@ -65,20 +44,9 @@ jobs:
       matrix:
         node-version: [22.x]
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - uses: MetaMask/action-checkout-and-setup@main
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - name: Install dependencies via Yarn
-        run: yarn --immutable --immutable-cache
+          is-high-risk-environment: false
       - run: yarn lint
       - name: Validate RC changelog
         if: ${{ startsWith(github.head_ref, 'release/') }}
@@ -102,20 +70,9 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - uses: MetaMask/action-checkout-and-setup@main
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - name: Install dependencies via Yarn
-        run: yarn --immutable --immutable-cache
+          is-high-risk-environment: false
       - run: yarn test
       - name: Require clean working directory
         shell: bash
@@ -133,18 +90,9 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - uses: MetaMask/action-checkout-and-setup@main
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+          is-high-risk-environment: false
       - name: Install dependencies via Yarn
         run: rm yarn.lock && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
       - run: yarn test

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: MetaMask/action-checkout-and-setup@main
+      - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
           cache-node-modules: true
@@ -24,7 +24,7 @@ jobs:
       matrix:
         node-version: [22.x]
     steps:
-      - uses: MetaMask/action-checkout-and-setup@main
+      - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
       - run: yarn build
@@ -44,7 +44,7 @@ jobs:
       matrix:
         node-version: [22.x]
     steps:
-      - uses: MetaMask/action-checkout-and-setup@main
+      - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
       - run: yarn lint
@@ -70,7 +70,7 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: MetaMask/action-checkout-and-setup@main
+      - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
       - run: yarn test
@@ -90,7 +90,7 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: MetaMask/action-checkout-and-setup@main
+      - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
       - name: Install dependencies via Yarn

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
-          cache-node-modules: true
+          cache-node-modules: ${{ matrix.node-version == '22.x' }}
 
   build:
     name: Build

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,7 +21,8 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: MetaMask/action-checkout-and-setup@v1
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
 

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,18 +21,18 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: MetaMask/action-checkout-and-setup@main
         with:
-          # This is to guarantee that the most recent tag is fetched.
-          # This can be configured to a more reasonable value by consumers.
+          is-high-risk-environment: true
+
+          # This is to guarantee that the most recent tag is fetched. This can
+          # be configured to a more reasonable value by consumers.
           fetch-depth: 0
+
           # We check out the specified branch, which will be used as the base
           # branch for all git operations and the release PR.
           ref: ${{ github.event.inputs.base-branch }}
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
+
       - uses: MetaMask/action-create-release-pr@v4
         with:
           release-type: ${{ github.event.inputs.release-type }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: MetaMask/action-checkout-and-setup@main
+      - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,8 @@ jobs:
     name: Check workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: MetaMask/action-checkout-and-setup@v1
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
       - name: Download actionlint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: MetaMask/action-checkout-and-setup@main
+      - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
       - name: Download actionlint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,9 @@ jobs:
     name: Check workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: MetaMask/action-checkout-and-setup@main
+        with:
+          is-high-risk-environment: false
       - name: Download actionlint
         id: download-actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.23

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Ensure `destination_dir` is not empty
         if: ${{ inputs.destination_dir == '' }}
         run: exit 1
-      - uses: MetaMask/action-checkout-and-setup@main
+      - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
       - name: Run build script

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,15 +21,9 @@ jobs:
       - name: Ensure `destination_dir` is not empty
         if: ${{ inputs.destination_dir == '' }}
         run: exit 1
-      - uses: actions/checkout@v4
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - uses: MetaMask/action-checkout-and-setup@main
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Install dependencies via Yarn
-        run: yarn --immutable
+          is-high-risk-environment: true
       - name: Run build script
         run: yarn build:docs
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Ensure `destination_dir` is not empty
         if: ${{ inputs.destination_dir == '' }}
         run: exit 1
-      - uses: MetaMask/action-checkout-and-setup@v1
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
       - name: Run build script

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: MetaMask/action-checkout-and-setup@main
+      - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
@@ -38,7 +38,7 @@ jobs:
     needs: publish-release
     runs-on: ubuntu-latest
     steps:
-      - uses: MetaMask/action-checkout-and-setup@main
+      - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:
-      - uses: MetaMask/action-checkout-and-setup@main
+      - uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,8 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: MetaMask/action-checkout-and-setup@v1
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
@@ -38,7 +39,8 @@ jobs:
     needs: publish-release
     runs-on: ubuntu-latest
     steps:
-      - uses: MetaMask/action-checkout-and-setup@v1
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
@@ -60,7 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:
-      - uses: MetaMask/action-checkout-and-setup@v1
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,15 +15,10 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: MetaMask/action-checkout-and-setup@main
         with:
+          is-high-risk-environment: true
           ref: ${{ github.sha }}
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
       - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -43,15 +38,10 @@ jobs:
     needs: publish-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: MetaMask/action-checkout-and-setup@main
         with:
+          is-high-risk-environment: true
           ref: ${{ github.sha }}
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
       - name: Restore build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -70,15 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:
-      - uses: actions/checkout@v4
+      - uses: MetaMask/action-checkout-and-setup@main
         with:
+          is-high-risk-environment: true
           ref: ${{ github.sha }}
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
       - name: Restore build artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This implements `MetaMask/action-checkout-and-setup`, which replaces the checkout and Node.js setup steps in CI.