### PR TITLE
Update `MetaMask/action-security-code-scanner` and run as part of main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check-workflows
+      - analyse-code
       - build-lint-test
     outputs:
       PASSED: ${{ steps.set-output.outputs.PASSED }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,18 @@ jobs:
         run: ${{ steps.download-actionlint.outputs.executable }} -color
         shell: bash
 
+  analyse-code:
+    name: Code scanner
+    needs: check-workflows
+    uses: ./.github/workflows/security-code-scanner.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    secrets:
+      SECURITY_SCAN_METRICS_TOKEN: ${{ secrets.SECURITY_SCAN_METRICS_TOKEN }}
+      APPSEC_BOT_SLACK_WEBHOOK: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
+
   build-lint-test:
     name: Build, lint, and test
     uses: ./.github/workflows/build-lint-test.yml

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -1,12 +1,12 @@
 name: MetaMask Security Code Scanner
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_call:
+    secrets:
+      SECURITY_SCAN_METRICS_TOKEN:
+        required: false
+      APPSEC_BOT_SLACK_WEBHOOK:
+        required: false
   workflow_dispatch:
 
 jobs:
@@ -17,8 +17,8 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - name: MetaMask Security Code Scanner
-        uses: MetaMask/Security-Code-Scanner@main
+      - name: Analyse code
+        uses: MetaMask/action-security-code-scanner@v1
         with:
           repo: ${{ github.repository }}
           paths_ignored: |

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   run-security-scan:
+    name: Run security scan
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
`MetaMask/Security-Code-Scanner` was renamed to `MetaMask/action-security-code-scanner`, and is now properly versioned as well. I've updated the workflow to use `MetaMask/action-security-code-scanner@v1`, and also changed it to run as part of the main workflow.

## Examples

We use this in the Snaps repo: https://github.com/MetaMask/snaps/blob/0d9472d5f4110fdd9b657220a51c53cbac6a2675/.github/workflows/main.yml#L24-L34
