### PR TITLE
Remove unnecessary Yarn install from publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: yarn --immutable
       - run: yarn build
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
When migrating to `MetaMask/action-checkout-and-setup`, we accidentally forgot to remove this `yarn install`. It's redundant, since the workflow itself will handle it.