### PR TITLE
Don't cache ESLint results

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint:constraints": "yarn constraints",
     "lint:dependencies": "depcheck && yarn dedupe --check",
     "lint:dependencies:fix": "depcheck && yarn dedupe",
-    "lint:eslint": "eslint . --cache",
+    "lint:eslint": "eslint .",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:constraints --fix && yarn lint:misc --write && yarn lint:dependencies:fix && yarn lint:changelog",
     "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.yml' '!.yarnrc.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern",
     "prepack": "./scripts/prepack.sh",


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

The `eslint` executable takes a `--cache` option, which instructs ESLint to save the results of linting for each file, skipping linting in the future for files that haven't changed. While this does tend to make repeated runs faster, in other repos where this technique is also used, we've noticed that the cache can also give misleading output when running `eslint` with various other options, making debugging lint issues frustrating. It is better in the long run to disable caching.

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove ESLint cache by changing `lint:eslint` script from `eslint . --cache` to `eslint .`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa92948a2f1f8391a7280248e36305cae4469de0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->