### PR TITLE
ci: Add explicit permissions to workflows

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -3,6 +3,9 @@ name: Build, Lint, and Test
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     name: Prepare

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check-workflows:
     name: Check workflows
@@ -71,6 +74,7 @@ jobs:
       - check-workflows
       - analyse-code
       - build-lint-test
+    permissions: {}
     outputs:
       PASSED: ${{ steps.set-output.outputs.PASSED }}
     steps:
@@ -83,6 +87,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: all-jobs-completed
+    permissions: {}
     steps:
       - name: Check that all jobs have passed
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,6 +9,10 @@ on:
         required: true
       PUBLISH_DOCS_TOKEN:
         required: true
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
This fixes a bunch of CodeQL alerts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that narrows workflow token permissions; main risk is unexpected permission-related failures if a step implicitly relied on broader defaults.
> 
> **Overview**
> Sets explicit default `permissions` on the reusable workflows (`build-lint-test.yml`, `publish-release.yml`) and the `main.yml` workflow to `contents: read` to satisfy security tooling and follow least-privilege defaults.
> 
> Further restricts the `main.yml` aggregation jobs (`all-jobs-completed`, `all-jobs-pass`) by explicitly setting `permissions: {}` so they run with no `GITHUB_TOKEN` access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ef8fa015a88d417897da75cdeb18c7ba29767ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->