### PR TITLE
ci: Bump all actions to latest version

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md#configuration-file
+
+paths:
+  .github/workflows/create-release-pr.yml:
+    ignore:
+      # `create-release-pr` has an empty string value for the `release-type`
+      # input, which is intentional and valid.
+      - 'string should not be empty'

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -12,7 +12,7 @@ jobs:
         node-version: [20.x, 22.x, 24.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
@@ -27,7 +27,7 @@ jobs:
         node-version: [24.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
@@ -49,7 +49,7 @@ jobs:
         node-version: [24.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
@@ -77,7 +77,7 @@ jobs:
         node-version: [20.x, 22.x, 24.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
@@ -99,7 +99,7 @@ jobs:
         node-version: [20.x, 22.x, 24.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -4,15 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       base-branch:
-        description: "The base branch for git operations and the pull request."
-        default: "main"
+        description: 'The base branch for git operations and the pull request.'
+        default: 'main'
         required: true
       release-type:
         description: 'A SemVer version diff, i.e. major, minor, or patch. Mutually exclusive with "release-version".'
         required: false
         type: choice
         options:
-          - ""
+          - ''
           - major
           - minor
           - patch

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -4,12 +4,18 @@ on:
   workflow_dispatch:
     inputs:
       base-branch:
-        description: 'The base branch for git operations and the pull request.'
-        default: 'main'
+        description: "The base branch for git operations and the pull request."
+        default: "main"
         required: true
       release-type:
         description: 'A SemVer version diff, i.e. major, minor, or patch. Mutually exclusive with "release-version".'
         required: false
+        type: choice
+        options:
+          - ""
+          - major
+          - minor
+          - patch
       release-version:
         description: 'A specific version to bump to. Mutually exclusive with "release-type".'
         required: false
@@ -22,7 +28,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,11 @@ jobs:
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash) 1.7.12
         shell: bash
       - name: Check workflow files
-        run: ${{ steps.download-actionlint.outputs.executable }} -color
+        env:
+          ACTIONLINT_EXECUTABLE: ${{ steps.download-actionlint.outputs.executable }}
+        run: |
+          echo "::add-matcher::.github/actionlint-matcher.json"
+          "$ACTIONLINT_EXECUTABLE" -color
         shell: bash
 
   analyse-code:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
       - name: Download actionlint
         id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.23
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash) 1.7.12
         shell: bash
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,7 +22,7 @@ jobs:
         if: ${{ inputs.destination_dir == '' }}
         run: exit 1
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
       - name: Run build script

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,8 +10,32 @@ on:
       PUBLISH_DOCS_TOKEN:
         required: true
 jobs:
+  publish-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
+        with:
+          is-high-risk-environment: true
+          ref: ${{ github.sha }}
+      - uses: MetaMask/action-publish-release@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: yarn build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: publish-release-artifacts-${{ github.sha }}
+          retention-days: 4
+          include-hidden-files: true
+          path: |
+            ./dist
+            ./node_modules/.yarn-state.yml
+
   publish-npm-dry-run:
-    name: Publish to NPM (dry run)
+    needs: publish-release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
@@ -33,7 +57,6 @@ jobs:
           SKIP_PREPACK: true
 
   publish-npm:
-    name: Publish to NPM
     needs: publish-npm-dry-run
     runs-on: ubuntu-latest
     environment: npm-publish
@@ -57,7 +80,6 @@ jobs:
           SKIP_PREPACK: true
 
   get-release-version:
-    name: Get release version
     needs: publish-npm
     runs-on: ubuntu-latest
     outputs:
@@ -91,29 +113,3 @@ jobs:
       destination_dir: latest
     secrets:
       PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
-
-  publish-release:
-    name: Publish release to GitHub
-    needs: publish-npm
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v3
-        with:
-          is-high-risk-environment: true
-          ref: ${{ github.sha }}
-      - uses: MetaMask/action-publish-release@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: yarn build
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: publish-release-artifacts-${{ github.sha }}
-          retention-days: 4
-          include-hidden-files: true
-          path: |
-            ./dist
-            ./node_modules/.yarn-state.yml

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,41 +10,17 @@ on:
       PUBLISH_DOCS_TOKEN:
         required: true
 jobs:
-  publish-release:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
-        with:
-          is-high-risk-environment: true
-          ref: ${{ github.sha }}
-      - uses: MetaMask/action-publish-release@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: yarn build
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v5
-        with:
-          name: publish-release-artifacts-${{ github.sha }}
-          retention-days: 4
-          include-hidden-files: true
-          path: |
-            ./dist
-            ./node_modules/.yarn-state.yml
-
   publish-npm-dry-run:
-    needs: publish-release
+    name: Publish to NPM (dry run)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
       - name: Restore build artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Dry Run Publish
@@ -57,17 +33,18 @@ jobs:
           SKIP_PREPACK: true
 
   publish-npm:
+    name: Publish to NPM
     needs: publish-npm-dry-run
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
       - name: Restore build artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Publish
@@ -80,6 +57,7 @@ jobs:
           SKIP_PREPACK: true
 
   get-release-version:
+    name: Get release version
     needs: publish-npm
     runs-on: ubuntu-latest
     outputs:
@@ -113,3 +91,29 @@ jobs:
       destination_dir: latest
     secrets:
       PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
+
+  publish-release:
+    name: Publish release to GitHub
+    needs: publish-npm
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
+        with:
+          is-high-risk-environment: true
+          ref: ${{ github.sha }}
+      - uses: MetaMask/action-publish-release@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: yarn build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: publish-release-artifacts-${{ github.sha }}
+          retention-days: 4
+          include-hidden-files: true
+          path: |
+            ./dist
+            ./node_modules/.yarn-state.yml


### PR DESCRIPTION
This bumps all GitHub Actions to their latest versions. From what I can tell, we shouldn't be affected by any of the breaking changes (mainly Node.js 24 bump).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI/release automation dependencies (checkout/setup, artifact upload/download, and actionlint), which could alter workflow behavior or break publishing if versions introduce subtle incompatibilities.
> 
> **Overview**
> **Updates CI/release GitHub Actions to newer major versions.** All workflows switch `MetaMask/action-checkout-and-setup` from `v2` to `v3`, and the release pipeline bumps `actions/upload-artifact` to `v7` and `actions/download-artifact` to `v8`.
> 
> **Improves workflow linting signal.** `actionlint` is updated (download script SHA + version to `1.7.12`) and the workflow now registers a new problem matcher (`.github/actionlint-matcher.json`) and adds `.github/actionlint.yml` config to ignore an intentional empty-string input; `create-release-pr.yml` also makes `release-type` an explicit `choice` (including empty string) to match that intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9983f80d94ee92748403a4d2529f9c1077bc084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->