### PR TITLE
ci: Publish release to GitHub after NPM

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -36,9 +36,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
+          is-high-risk-environment: true
           ref: ${{ github.sha }}
       - name: Restore build artifacts
         uses: actions/download-artifact@v8
@@ -59,9 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
+          is-high-risk-environment: true
           ref: ${{ github.sha }}
       - name: Restore build artifacts
         uses: actions/download-artifact@v8
@@ -113,7 +115,7 @@ jobs:
       PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
 
   publish-release:
-    name: Publish release to GitHub
+    name: Publish to GitHub
     needs: publish-npm
     permissions:
       contents: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,9 +10,8 @@ on:
       PUBLISH_DOCS_TOKEN:
         required: true
 jobs:
-  publish-release:
-    permissions:
-      contents: write
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
@@ -20,10 +19,8 @@ jobs:
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
-      - uses: MetaMask/action-publish-release@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: yarn build
+      - name: Build
+        run: yarn build
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -35,13 +32,13 @@ jobs:
             ./node_modules/.yarn-state.yml
 
   publish-npm-dry-run:
-    needs: publish-release
+    name: Publish to NPM (dry run)
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v3
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
-          is-high-risk-environment: true
           ref: ${{ github.sha }}
       - name: Restore build artifacts
         uses: actions/download-artifact@v8
@@ -57,14 +54,14 @@ jobs:
           SKIP_PREPACK: true
 
   publish-npm:
+    name: Publish to NPM
     needs: publish-npm-dry-run
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:
-      - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v3
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
-          is-high-risk-environment: true
           ref: ${{ github.sha }}
       - name: Restore build artifacts
         uses: actions/download-artifact@v8
@@ -80,6 +77,7 @@ jobs:
           SKIP_PREPACK: true
 
   get-release-version:
+    name: Get release version
     needs: publish-npm
     runs-on: ubuntu-latest
     outputs:
@@ -113,3 +111,19 @@ jobs:
       destination_dir: latest
     secrets:
       PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
+
+  publish-release:
+    name: Publish release to GitHub
+    needs: publish-npm
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
+        with:
+          is-high-risk-environment: true
+          ref: ${{ github.sha }}
+      - uses: MetaMask/action-publish-release@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reorders the `publish-release` workflow to move the publish release to GitHub step after NPM publishing. NPM publish requires approval, and occasionally a release may be rejected and reverted, currently requiring manual removal of the Git tags and GitHub release, since those are always created before the approval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the sequencing of the release pipeline (artifact build/publish dependencies), which could affect release automation if any job ordering assumptions were relied on.
> 
> **Overview**
> The `publish-release` GitHub Actions workflow is restructured so the build happens first, then NPM dry-run and NPM publish run from the built artifacts, and only **after NPM publish succeeds** does it create the GitHub release.
> 
> This avoids creating tags/releases before the `npm-publish` environment approval, and adds clearer job naming while keeping the docs publish steps (`gh-pages` and `latest`) dependent on the post-publish version/output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff690d0bce726ed932dca79a26bc9996ff85fa11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->