### PR TITLE
chore: Add `approvedGitRepositories` to Yarn config

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,20 +1,19 @@
+# Allowlist for Git repositories that can be used as dependencies. We set it to
+# an empty array to disallow all Git dependencies, as we don't use any and they
+# can be a security risk.
+approvedGitRepositories: []
+
 compressionLevel: mixed
 
 enableGlobalCache: false
 
 enableScripts: false
 
-enableTelemetry: 0
+enableTelemetry: false
 
 logFilters:
   - code: YN0004
     level: discard
-
-nodeLinker: node-modules
-
-plugins:
-  - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
-    spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"
 
 # Configure the NPM minimal age gate to 3 days, meaning packages must be at
 # least 3 days old to be installed.
@@ -26,3 +25,9 @@ npmPreapprovedPackages:
   - '@metamask/*'
   - '@metamask-previews/*'
   - '@lavamoat/*'
+
+nodeLinker: node-modules
+
+plugins:
+  - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
+    spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
-  "packageManager": "yarn@4.10.3",
+  "packageManager": "yarn@4.14.1",
   "lavamoat": {
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10
 
 "@aashutoshrathi/word-wrap@npm:^1.2.3":


### PR DESCRIPTION
Yarn recently added an `approvedGitRepositories` setting which is an allowlist for allowed Git repositories that can be installed as dependencies. Git repositories have some security risks, and we don't typically use them, so we can set it to an empty array to disallow Git repositories.

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes package-manager behavior (blocks all Git-based dependencies) and updates the Yarn version/lockfile format, which could affect installs/CI if any workflow relied on the previous tooling behavior.
> 
> **Overview**
> Adds Yarn’s `approvedGitRepositories: []` setting to explicitly **disallow Git-based dependencies**.
> 
> Updates Yarn configuration semantics (`enableTelemetry: false`), bumps `packageManager` to `yarn@4.14.1`, and regenerates `yarn.lock` to the newer lockfile metadata version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c2cd73577425d21473cef3e8eb3da2129dfd59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->