### PR TITLE
ci: Introduce zizmor action and address findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       interval: 'daily'
       time: '06:00'
+    cooldown:
+      default-days: 3
     allow:
       - dependency-name: '@metamask/*'
     target-branch: 'main'
@@ -19,6 +21,8 @@ updates:
     schedule:
       interval: 'daily'
       time: '06:00'
+    cooldown:
+      default-days: 3
     allow:
       - dependency-name: 'MetaMask/*'
       - dependency-name: 'actions/*'

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -18,6 +18,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
           node-version: ${{ matrix.node-version }}
           cache-node-modules: ${{ matrix.node-version == '24.x' }}
 
@@ -33,6 +34,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
           node-version: ${{ matrix.node-version }}
       - run: yarn build
       - name: Require clean working directory
@@ -55,6 +57,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
           node-version: ${{ matrix.node-version }}
       - run: yarn lint
       - name: Validate RC changelog
@@ -71,6 +74,21 @@ jobs:
             exit 1
           fi
 
+  lint-workflows:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Lint workflows
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d
+        with:
+          advanced-security: false
+          annotations: true
+          version: v1.25.2
+
   test:
     name: Test
     needs: prepare
@@ -83,6 +101,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
           node-version: ${{ matrix.node-version }}
       - run: yarn test
       - name: Require clean working directory
@@ -105,6 +124,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies via Yarn
         run: rm yarn.lock && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -31,6 +31,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
+          persist-credentials: false
 
           # This is to guarantee that the most recent tag is fetched. This can
           # be configured to a more reasonable value by consumers.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
       - name: Download actionlint
         id: download-actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash) 1.7.12
@@ -90,9 +91,10 @@ jobs:
     permissions: {}
     steps:
       - name: Check that all jobs have passed
+        env:
+          PASSED: ${{ needs.all-jobs-completed.outputs.PASSED }}
         run: |
-          passed="${{ needs.all-jobs-completed.outputs.PASSED }}"
-          if [[ $passed != "true" ]]; then
+          if [[ $PASSED != "true" ]]; then
             exit 1
           fi
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -25,6 +25,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
+          persist-credentials: false
       - name: Run build script
         run: yarn build:docs
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch

--- a/.github/workflows/publish-rc-docs.yml
+++ b/.github/workflows/publish-rc-docs.yml
@@ -4,18 +4,24 @@ on:
   push:
     branches: 'release/**'
 
+permissions:
+  contents: read
+
 jobs:
   get-release-version:
     name: Get release version
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       release-version: ${{ steps.release-name.outputs.RELEASE_VERSION }}
     steps:
       - name: Extract release version from branch name
         id: release-name
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
-          BRANCH_NAME='${{ github.ref_name }}'
           echo "RELEASE_VERSION=v${BRANCH_NAME#release/}" >> "$GITHUB_OUTPUT"
+
   publish-to-gh-pages:
     name: Publish docs to `rc-${{ needs.get-release-version.outputs.release-version }}` directory of `gh-pages` branch
     permissions:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
+          persist-credentials: false
           ref: ${{ github.sha }}
       - name: Build
         run: yarn build
@@ -44,6 +45,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
+          persist-credentials: false
           ref: ${{ github.sha }}
       - name: Restore build artifacts
         uses: actions/download-artifact@v8
@@ -70,6 +72,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
+          persist-credentials: false
           ref: ${{ github.sha }}
       - name: Restore build artifacts
         uses: actions/download-artifact@v8
@@ -96,6 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           ref: ${{ github.sha }}
       - id: get-release-version
         shell: bash
@@ -134,6 +138,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
+          persist-credentials: false
           ref: ${{ github.sha }}
       - uses: MetaMask/action-publish-release@v3
         env:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,16 @@
+# Please see the documentation for all configuration options:
+# https://docs.zizmor.sh/configuration/
+
+rules:
+  dependabot-cooldown:
+    config:
+      # Change the minimum allowed cooldown period for Dependabot to 3 days.
+      days: 3
+
+  unpinned-uses:
+    config:
+      policies:
+        # Allow `actions/*` and `MetaMask/*` to be pinned to a version instead
+        # of only to a commit hash.
+        actions/*: ref-pin
+        MetaMask/*: ref-pin


### PR DESCRIPTION
Introduces [zizmor](https://docs.zizmor.sh/), a static analysis tool for GitHub Actions workflows, via a new `lint-workflows` job in the build-lint-test workflow and a `zizmor.yml` configuration file.

Fixes all findings reported by zizmor:

- Fix template injection in `publish-rc-docs.yml` by moving `github.ref_name` to an env var instead of interpolating it directly in the shell script
- Fix template injection in `main.yml` by moving a job output to an env var
- Add `permissions: contents: read` and `permissions: {}` to `publish-rc-docs.yml` to limit default permissions
- Add `persist-credentials: false` to all `action-checkout-and-setup` and `actions/checkout` usages
- Add `dependabot-cooldown` to `dependabot.yml` to satisfy the `dependabot-cooldown` zizmor rule

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI, Dependabot, and workflow security hardening with no application runtime impact.
> 
> **Overview**
> Adds **zizmor** static analysis for GitHub Actions via a new **`lint-workflows`** job in `build-lint-test.yml` and a **`.github/zizmor.yml`** config (3-day Dependabot cooldown alignment and relaxed pinning for `actions/*` and `MetaMask/*`).
> 
> Addresses zizmor findings across CI: **`persist-credentials: false`** on all checkout/setup steps; **template-injection** hardening by passing `github.ref_name` and job outputs through **`env`** in `publish-rc-docs.yml` and `main.yml`; **tighter default permissions** on `publish-rc-docs.yml`; and **`cooldown.default-days: 3`** on both Dependabot ecosystems in `dependabot.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f2e163a68186bf8bd1e07244ba07faf342598df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->