### PR TITLE
ci: Remove zizmor workflow lint job

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -74,21 +74,6 @@ jobs:
             exit 1
           fi
 
-  lint-workflows:
-    name: Lint workflows
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Lint workflows
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d
-        with:
-          advanced-security: false
-          annotations: true
-          version: v1.25.2
-
   test:
     name: Test
     needs: prepare


### PR DESCRIPTION
The Zizmor action has been added to `MetaMask/action-security-code-scanner`, which is already run as part of the `analyse-code` job in the main workflow. The standalone `lint-workflows` job in `build-lint-test.yml` is therefore redundant and can be removed.

## Examples

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that removes duplicate workflow linting; security scanning should still run via the existing `analyse-code` job.
> 
> **Overview**
> Removes the standalone **`lint-workflows`** job from `build-lint-test.yml`, which ran **zizmor** via `zizmorcore/zizmor-action` on every build/lint/test workflow call.
> 
> Workflow security linting is no longer duplicated here because **zizmor** is already executed through **`MetaMask/action-security-code-scanner`** in the main pipeline’s **`analyse-code`** job. The reusable workflow now goes straight from **`lint`** to **`test`** with no separate workflow-lint step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c83e07127fda7ec124ba2b3f31d363bf8fd4d464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->