### PR TITLE
ci: Skip Yarn install in publish jobs that don't need deps

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,6 +47,7 @@ jobs:
           is-high-risk-environment: true
           persist-credentials: false
           ref: ${{ github.sha }}
+          skip-install: true
       - name: Restore build artifacts
         uses: actions/download-artifact@v8
         with:
@@ -74,6 +75,7 @@ jobs:
           is-high-risk-environment: true
           persist-credentials: false
           ref: ${{ github.sha }}
+          skip-install: true
       - name: Restore build artifacts
         uses: actions/download-artifact@v8
         with:
@@ -140,6 +142,7 @@ jobs:
           is-high-risk-environment: true
           persist-credentials: false
           ref: ${{ github.sha }}
+          skip-install: true
       - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `publish-npm-dry-run`, `publish-npm`, and `publish-release` jobs in the release workflow don't need the project's `node_modules` installed:

- `publish-npm-dry-run` and `publish-npm` use `MetaMask/action-npm-publish`, which runs `yarn pack` / `yarn npm publish` against the already-built `./dist` (restored from the build artifact). These commands don't read `node_modules`.
- `publish-release` uses `MetaMask/action-publish-release`, which only reads `package.json` and runs its own bundled JS to create the GitHub release.

Running `yarn --immutable` on each of these jobs is wasted work. This PR sets `skip-install: true` on `action-checkout-and-setup@v3` in those three jobs, so they still get a checkout and Node setup but skip the install.

The `build` job and `publish-docs.yml` are unchanged — they run `yarn build` / `yarn build:docs` and genuinely need dependencies.

## Examples

N/A — internal CI tweak with no template surface changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that avoids redundant installs; publish behavior still depends on the existing build artifact and unchanged build/docs jobs.
> 
> **Overview**
> Adds **`skip-install: true`** to `MetaMask/action-checkout-and-setup@v3` in the **`publish-npm-dry-run`**, **`publish-npm`**, and **`publish-release`** jobs so those steps still check out the repo and set up Node but **skip `yarn --immutable`**.
> 
> NPM publish jobs continue to restore **`./dist`** from the build artifact and publish via **`action-npm-publish`**; the GitHub release job still uses **`action-publish-release`** with only **`package.json`**. The **`build`** job (and docs workflows) are unchanged and still install deps for **`yarn build`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880197635bc775d13b4fede8c1b66d6547d6d929. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->