### PR TITLE
ci: use explicit dry-run input for npm publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Dry Run Publish
         uses: MetaMask/action-npm-publish@v6
         with:
+          dry-run: true
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers
         env:
@@ -83,6 +84,7 @@ jobs:
       - name: Publish
         uses: MetaMask/action-npm-publish@v6
         with:
+          dry-run: false
           # This `NPM_TOKEN` needs to be manually set to publish a package for
           # the first time only.
           # Look in the repository settings under "Environments", and set this


### PR DESCRIPTION
We now pass in an explicit `dry-run` parameter when calling `action-npm-publish`, rather than relying on it to infer whether it's a dry run or not from context.

This ensures that if authentication is not setup correctly, CI will fail rather than silently succeeding with a dry run.

## Examples

First used here: https://github.com/MetaMask/core/pull/9102

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to npm publish action inputs; no runtime or application code affected.
> 
> **Overview**
> The **publish-release** workflow now passes an explicit **`dry-run`** flag to **`MetaMask/action-npm-publish@v6`** instead of letting the action infer mode from context.
> 
> The dry-run job sets **`dry-run: true`**; the real **`npm-publish`** job sets **`dry-run: false`**. Misconfigured auth on the publish step should surface as a failure instead of a silent dry run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0380daa21133a9f28ee674deabd9ccae3a889ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->