### PR TITLE
chore: Add configs for Yarn 1 and NPM

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+## Make using NPM impossible.
+offline=true
+
+## Ignore scripts just in case.
+ignore-scripts=true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+## Ignore scripts in case Yarn 1 is accidentally used.
+ignore-scripts true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -30,4 +30,4 @@ npmPreapprovedPackages:
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
-    spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"
+    spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'


### PR DESCRIPTION
This adds a config for Yarn 1 and NPM, in case either tool is accidentally used.

- The Yarn 1 config blocks install scripts.
- The NPM config enables offline mode, which prevents NPM from resolving dependencies, and disables install scripts just in case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only config with no runtime or application logic changes.
> 
> **Overview**
> Adds **accidental fallback tooling configs** so installs stay on the intended Yarn Berry workflow.
> 
> A new **`.npmrc`** sets `offline=true` (blocks dependency resolution) and `ignore-scripts=true`. A new **`.yarnrc`** sets `ignore-scripts` for Yarn Classic. **`.yarnrc.yml`** only normalizes quote style on the LavaMoat allow-scripts plugin `spec` URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2456f058c771c2638df41a535ec3f9fa586c51a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->