### PR TITLE
chore: add `sha256` hash to `packageManager` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
-  "packageManager": "yarn@4.16.0",
+  "packageManager": "yarn@4.16.0+sha256.ba05224324578801b9cc98170d64aa50b9a36733b440fb0942306da3fbbdc7d1",
   "lavamoat": {
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false,

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -222,6 +222,29 @@ function expectExports(workspace) {
     });
 }
 
+/**
+ * Expect that the workspace has a package manager set, and that it is Yarn with
+ * a sha256 hash.
+ *
+ * @param {Workspace} workspace - The workspace to check.
+ */
+function expectYarnPackageManager(workspace) {
+  expectWorkspaceField(workspace, 'packageManager');
+
+  const { packageManager } = workspace.manifest;
+  if (!packageManager.startsWith('yarn@')) {
+    workspace.error(
+      `Expected packageManager to start with "yarn@<version>", but got "${packageManager}".`,
+    );
+  }
+
+  if (!packageManager.includes('sha256')) {
+    workspace.error(
+      `Expected packageManager to include a sha256 hash, but got "${packageManager}".`,
+    );
+  }
+}
+
 module.exports = defineConfig({
   /**
    * Define the constraints for this project.
@@ -262,6 +285,9 @@ module.exports = defineConfig({
 
     // The package must specify the expected minimum Node versions
     workspace.set('engines.node', '^20 || ^22 || >=24');
+
+    // The package must specify Yarn as the package manager, with a sha256 hash.
+    expectYarnPackageManager(workspace);
 
     // The package must provide the location of the CommonJS-compatible
     // entrypoint and its matching type declaration file.


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

The root `package.json` previously set `packageManager` to `yarn@4.16.0` with no integrity hash. Corepack supports an optional `+sha256.<hash>` suffix that pins the Yarn binary to a known checksum, ensuring that anyone running `corepack` against this repo gets the exact same Yarn binary that was vetted.

This PR adds the sha256 hash to the `packageManager` field. A new `expectYarnPackageManager` constraint asserts that `packageManager` starts with `yarn@` and includes a sha256 hash, so the hash can evolve when Yarn is bumped without requiring a constraint change at the same time.

## Examples

See `MetaMask/core#9122` for the equivalent change in the `core` monorepo.