### PR TITLE
chore: restrict Dependabot GitHub Actions updates to major versions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,5 +26,10 @@ updates:
     allow:
       - dependency-name: 'MetaMask/*'
       - dependency-name: 'actions/*'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
     target-branch: 'main'
     open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot was opening PRs for minor and patch updates to GitHub Actions (e.g., `MetaMask/action-is-release@v2.2.0`). Since we use floating major tags (e.g., `MetaMask/action-is-release@v2`), minor and patch bumps are automatically picked up and don't need separate PRs. This adds an `ignore` block to skip `semver-minor` and `semver-patch` updates, so Dependabot will only open PRs for major version bumps (e.g., `v2` → `v3`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI automation config only; no runtime or application code changes.
> 
> **Overview**
> **Dependabot** for the `github-actions` ecosystem now ignores **minor** and **patch** version updates via a new `ignore` block on `dependency-name: '*'`.
> 
> PRs will only be opened for **major** bumps (e.g. `@v2` → `@v3`), which matches workflows that pin floating major tags like `MetaMask/action-checkout-and-setup@v3` so routine patch/minor action releases do not generate redundant upgrade PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c72742e2e6840162afde86fa8d7b8969ff6aa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->